### PR TITLE
feat: 뉴스 목록 조회 API 연동

### DIFF
--- a/economic_fe/lib/data/models/article_model.dart
+++ b/economic_fe/lib/data/models/article_model.dart
@@ -26,5 +26,16 @@ class ArticleModel with ChangeNotifier {
     this.createdDate,
   });
 
-  // void
+  factory ArticleModel.fromJson(Map<String, dynamic> json) {
+    return ArticleModel(
+      id: json['id'],
+      title: json['title'],
+      content: json['content'],
+      publisher: json['publisher'],
+      views: json['views'],
+      url: json['url'],
+      category: json['category'],
+      createdDate: json['createdDate'],
+    );
+  }
 }

--- a/economic_fe/lib/data/models/article_model.dart
+++ b/economic_fe/lib/data/models/article_model.dart
@@ -1,0 +1,30 @@
+// 뉴스 모델
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ArticleModel with ChangeNotifier {
+  int? id;
+  String? title;
+  String? content;
+  String? publisher;
+  int? views;
+  String? url;
+  String? category;
+  String? createdDate;
+
+  ArticleModel({
+    this.id,
+    this.title,
+    this.content,
+    this.publisher,
+    this.views,
+    this.url,
+    this.category,
+    this.createdDate,
+  });
+
+  // void
+}

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -114,7 +114,11 @@ class RemoteDataSource {
 
       if (response.statusCode == 200) {
         debugPrint('GET 요청 성공');
-        return jsonDecode(response.body);
+
+        // return jsonDecode(response.body);
+        // 한글 깨지지 않도록 설정
+        final decodedResponse = jsonDecode(utf8.decode(response.bodyBytes));
+        return decodedResponse;
       } else {
         debugPrint('GET 요청 실패: (${response.statusCode})${response.body}');
         return response;
@@ -168,11 +172,19 @@ class RemoteDataSource {
   /// api/news
 
   static Future<dynamic> getNewsList(
-      int page, String sort, String category) async {
-    dynamic response = await _getApiWithHeader(
-      'api/news?page=$page&sort=$sort&category=$category',
-      accessToken,
-    );
+      int page, String sort, String? category) async {
+    dynamic response;
+    if (category != null) {
+      response = await _getApiWithHeader(
+        'api/news?page=$page&sort=$sort&category=$category',
+        accessToken,
+      );
+    } else {
+      response = await _getApiWithHeader(
+        'api/news?page=$page&sort=$sort',
+        accessToken,
+      );
+    }
 
     if (response != null) {
       print('응답 데이터 : $response');

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -4,6 +4,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
 class RemoteDataSource {
+  //기본 api 엔드포인트
   static String baseUrl = dotenv.env['API_URL']!;
 
   /// API POST
@@ -126,6 +127,13 @@ class RemoteDataSource {
   /// api/v1/level-test/quiz 레벨 테스트 퀴즈 목록 조회
   static Future<dynamic> getLevelTest() async {
     dynamic response = await _getApi('api/v1/level-test/quiz');
+    return response;
+  }
+
+  static Future<dynamic> getNewsList(
+      int page, String sort, String category) async {
+    dynamic response =
+        await _getApi('api/news?page=$page&sort=$sort&category=$category');
     return response;
   }
 }

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/',
+      initialRoute: '/article',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/view/screens/article/article_list_page.dart
+++ b/economic_fe/lib/view/screens/article/article_list_page.dart
@@ -55,102 +55,100 @@ class _ArticleListPageState extends State<ArticleListPage> {
                   children: [
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(0);
+                        controller.selectCategory("FINANCE");
                         controller.getNewsList(1, "RECENT", null);
                       },
                       child: CategoryTab(
-                        isSelected: controller.selectedCategoryIndex.value == 0,
+                        isSelected: controller.selectedCate.value == "FINANCE",
                         text: '전체',
                       ),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(1);
+                        controller.selectCategory("FINANCE");
                         controller.getNewsList(1, "RECENT", "FINANCE");
                       },
                       child: CategoryTab(
                           isSelected:
-                              controller.selectedCategoryIndex.value == 1,
+                              controller.selectedCate.value == "FINANCE",
                           text: 'FINANCE'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(2);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("INVESTMENT");
+                        controller.getNewsList(1, "RECENT", "INVESTMENT");
                       },
                       child: CategoryTab(
                           isSelected:
-                              controller.selectedCategoryIndex.value == 2,
+                              controller.selectedCate.value == "INVESTMENT",
                           text: 'INVESTMENT'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(3);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("NORMAL");
+                        controller.getNewsList(1, "RECENT", "NORMAL");
                       },
                       child: CategoryTab(
-                          isSelected:
-                              controller.selectedCategoryIndex.value == 3,
+                          isSelected: controller.selectedCate.value == "NORMAL",
                           text: 'NORMAL'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(4);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("GLOBAL");
+                        controller.getNewsList(1, "RECENT", "GLOBAL");
                       },
                       child: CategoryTab(
-                          isSelected:
-                              controller.selectedCategoryIndex.value == 4,
+                          isSelected: controller.selectedCate.value == "GLOBAL",
                           text: 'GLOBAL'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(5);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("INDUSTRY");
+                        controller.getNewsList(1, "RECENT", "INDUSTRY");
                       },
                       child: CategoryTab(
                           isSelected:
-                              controller.selectedCategoryIndex.value == 5,
+                              controller.selectedCate.value == "INDUSTRY",
                           text: 'INDUSTRY'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(6);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("REAL_ESTATE");
+                        controller.getNewsList(1, "RECENT", "REAL_ESTATE");
                       },
                       child: CategoryTab(
                           isSelected:
-                              controller.selectedCategoryIndex.value == 6,
+                              controller.selectedCate.value == "REAL_ESTATE",
                           text: 'REAL_ESTATE'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(7);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("ECONOMIC_ANALYSIS");
+                        controller.getNewsList(
+                            1, "RECENT", "ECONOMIC_ANALYSIS");
                       },
                       child: CategoryTab(
-                          isSelected:
-                              controller.selectedCategoryIndex.value == 7,
+                          isSelected: controller.selectedCate.value ==
+                              "ECONOMIC_ANALYSIS",
                           text: 'ECONOMIC_ANALYSIS'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(8);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("ECONOMIC_POLICY");
+                        controller.getNewsList(1, "RECENT", "ECONOMIC_POLICY");
                       },
                       child: CategoryTab(
-                          isSelected:
-                              controller.selectedCategoryIndex.value == 8,
+                          isSelected: controller.selectedCate.value ==
+                              "ECONOMIC_POLICY",
                           text: 'ECONOMIC_POLICY'),
                     ),
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory(9);
-                        controller.getNewsList(1, "RECENT", "FINANCE");
+                        controller.selectCategory("OTHER");
+                        controller.getNewsList(1, "RECENT", "OTHER");
                       },
                       child: CategoryTab(
-                          isSelected:
-                              controller.selectedCategoryIndex.value == 9,
+                          isSelected: controller.selectedCate.value == "OTHER",
                           text: 'OTHER'),
                     ),
                   ],
@@ -235,36 +233,59 @@ class _ArticleListPageState extends State<ArticleListPage> {
                                         color: Colors.white,
                                         borderRadius:
                                             BorderRadius.circular(12.0),
-                                        boxShadow: [
-                                          BoxShadow(
-                                            color: Colors.grey.withOpacity(0.3),
-                                            blurRadius: 8,
-                                            offset: const Offset(0, 4),
+                                        border: const Border(
+                                          bottom: BorderSide(
+                                            color: Color(0xFFD9D9D9),
+                                            width: 1,
                                           ),
-                                        ],
+                                        ),
+                                        // boxShadow: [
+                                        //   BoxShadow(
+                                        //     color: Colors.grey.withOpacity(0.3),
+                                        //     blurRadius: 8,
+                                        //     offset: const Offset(0, 4),
+                                        //   ),
+                                        // ],
                                       ),
                                       child: Column(
                                         crossAxisAlignment:
                                             CrossAxisAlignment.start,
                                         children: [
                                           Text(
-                                            news.title ?? "제목 없음",
+                                            "${news.category}",
                                             style: const TextStyle(
-                                              fontSize: 18,
-                                              fontWeight: FontWeight.bold,
+                                              color: Color(0xFF2BD6D6),
+                                              fontSize: 12,
+                                              fontWeight: FontWeight.w600,
+                                              letterSpacing: -0.3,
+                                              height: 1.3,
                                             ),
                                           ),
-                                          const SizedBox(height: 8),
                                           Text(
-                                            news.content ?? "내용 없음",
-                                            style:
-                                                const TextStyle(fontSize: 14),
-                                          ),
-                                          const SizedBox(height: 8),
-                                          Text(
-                                            "출처: ${news.publisher ?? "알 수 없음"}",
+                                            news.title ?? "제목 없음",
                                             style: const TextStyle(
-                                                color: Colors.grey),
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.w500,
+                                              height: 1.3,
+                                              letterSpacing: -0.4,
+                                            ),
+                                          ),
+                                          const SizedBox(height: 6),
+                                          // Text(
+                                          //   news.content ?? "내용 없음",
+                                          //   style:
+                                          //       const TextStyle(fontSize: 14),
+                                          // ),
+                                          // const SizedBox(height: 8),
+                                          Text(
+                                            news.publisher ?? "알 수 없음",
+                                            style: const TextStyle(
+                                              color: Color(0xFF2BD6D6),
+                                              fontSize: 12,
+                                              fontWeight: FontWeight.w400,
+                                              height: 1.5,
+                                              letterSpacing: -0.3,
+                                            ),
                                           ),
                                         ],
                                       ),

--- a/economic_fe/lib/view/screens/article/article_list_page.dart
+++ b/economic_fe/lib/view/screens/article/article_list_page.dart
@@ -7,13 +7,24 @@ import 'package:economic_fe/view_model/article/article_list_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-class ArticleListPage extends StatelessWidget {
+class ArticleListPage extends StatefulWidget {
   const ArticleListPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final ArticleListController controller = Get.put(ArticleListController());
+  State<ArticleListPage> createState() => _ArticleListPageState();
+}
 
+class _ArticleListPageState extends State<ArticleListPage> {
+  final ArticleListController controller = Get.put(ArticleListController());
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    controller.getNewsList(1, "RECENT", "FINANCE");
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Palette.background,
       appBar: AppBar(

--- a/economic_fe/lib/view/screens/article/article_list_page.dart
+++ b/economic_fe/lib/view/screens/article/article_list_page.dart
@@ -55,11 +55,11 @@ class _ArticleListPageState extends State<ArticleListPage> {
                   children: [
                     GestureDetector(
                       onTap: () {
-                        controller.selectCategory("FINANCE");
+                        controller.selectCategory("전체");
                         controller.getNewsList(1, "RECENT", null);
                       },
                       child: CategoryTab(
-                        isSelected: controller.selectedCate.value == "FINANCE",
+                        isSelected: controller.selectedCate.value == "전체",
                         text: '전체',
                       ),
                     ),
@@ -173,6 +173,8 @@ class _ArticleListPageState extends State<ArticleListPage> {
                             GestureDetector(
                               onTap: () {
                                 controller.selectOrder(0);
+                                controller.getNewsList(1, "POPULAR",
+                                    controller.selectedCate.value);
                               },
                               child: OrderTab(
                                 text: '인기순',
@@ -185,6 +187,8 @@ class _ArticleListPageState extends State<ArticleListPage> {
                             GestureDetector(
                               onTap: () {
                                 controller.selectOrder(1);
+                                controller.getNewsList(
+                                    1, "RECENT", controller.selectedCate.value);
                               },
                               child: OrderTab(
                                 text: '최신순',
@@ -239,13 +243,6 @@ class _ArticleListPageState extends State<ArticleListPage> {
                                             width: 1,
                                           ),
                                         ),
-                                        // boxShadow: [
-                                        //   BoxShadow(
-                                        //     color: Colors.grey.withOpacity(0.3),
-                                        //     blurRadius: 8,
-                                        //     offset: const Offset(0, 4),
-                                        //   ),
-                                        // ],
                                       ),
                                       child: Column(
                                         crossAxisAlignment:
@@ -271,16 +268,10 @@ class _ArticleListPageState extends State<ArticleListPage> {
                                             ),
                                           ),
                                           const SizedBox(height: 6),
-                                          // Text(
-                                          //   news.content ?? "내용 없음",
-                                          //   style:
-                                          //       const TextStyle(fontSize: 14),
-                                          // ),
-                                          // const SizedBox(height: 8),
                                           Text(
                                             news.publisher ?? "알 수 없음",
                                             style: const TextStyle(
-                                              color: Color(0xFF2BD6D6),
+                                              color: Color(0xFF767676),
                                               fontSize: 12,
                                               fontWeight: FontWeight.w400,
                                               height: 1.5,

--- a/economic_fe/lib/view/screens/article/article_list_page.dart
+++ b/economic_fe/lib/view/screens/article/article_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:economic_fe/data/models/article_model.dart';
 import 'package:economic_fe/view/theme/palette.dart';
 import 'package:economic_fe/view/widgets/category_tab.dart';
 import 'package:economic_fe/view/widgets/chatbot_fab.dart';
@@ -196,128 +197,207 @@ class _ArticleListPageState extends State<ArticleListPage> {
                         ),
                       ),
                       // 기사 목록
-                      Expanded(
-                        child: ListView.separated(
-                          shrinkWrap: true,
-                          itemCount: controller.articles.length, // 예시 데이터 갯수
-                          itemBuilder: (context, index) {
-                            final article = controller.articles[index];
-                            // 인기순과 최신순을 구분해서 데이터를 다르게 처리
-                            if (controller.selectedOrder.value == 0) {
-                              // 인기순
-                              return Padding(
-                                padding: const EdgeInsets.all(16),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    // 카테고리 이름
-                                    Text(
-                                      article.category,
-                                      style: const TextStyle(
-                                        color: Color(0xFF2AD6D6),
-                                        fontSize: 12,
-                                        fontWeight: FontWeight.w600,
-                                        height: 1.30,
-                                        letterSpacing: -0.30,
-                                      ),
-                                    ),
-                                    const SizedBox(
-                                      height: 6,
-                                    ),
+                      Obx(() {
+                        return FutureBuilder<List<ArticleModel>>(
+                          future: controller.getNewsList(
+                              1,
+                              controller.selectedSort.value,
+                              controller.selectedCate.value),
+                          builder: (context, snapshot) {
+                            if (snapshot.connectionState ==
+                                ConnectionState.waiting) {
+                              return const Center(
+                                child: CircularProgressIndicator(),
+                              );
+                            }
+                            // 에러인 경우
+                            if (snapshot.hasError) {
+                              return Center(
+                                child: Text("에러 발생 ${snapshot.error}"),
+                              );
+                            }
+                            // 데이터가 없을때
+                            if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                              return const Center(child: Text('뉴스 데이터가 없습니다.'));
+                            }
+                            final newsList = snapshot.data!;
 
-                                    Row(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.spaceBetween,
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        // 기사 헤드라인
-                                        GestureDetector(
-                                          onTap: () {
-                                            controller.toDetailPage(article);
-                                          },
-                                          child: SizedBox(
-                                            width: MediaQuery.of(context)
-                                                    .size
-                                                    .width -
-                                                80,
-                                            child: Text(
-                                              article.headline,
-                                              style: const TextStyle(
-                                                color: Color(0xFF111111),
-                                                fontSize: 16,
-                                                fontWeight: FontWeight.w500,
-                                                height: 1.30,
-                                                letterSpacing: -0.40,
-                                              ),
+                            return Expanded(
+                              child: ListView.builder(
+                                itemCount: newsList.length,
+                                itemBuilder: (context, index) {
+                                  final news = newsList[index];
+                                  return Padding(
+                                    padding: const EdgeInsets.all(8.0),
+                                    child: Container(
+                                      padding: const EdgeInsets.all(16.0),
+                                      decoration: BoxDecoration(
+                                        color: Colors.white,
+                                        borderRadius:
+                                            BorderRadius.circular(12.0),
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: Colors.grey.withOpacity(0.3),
+                                            blurRadius: 8,
+                                            offset: const Offset(0, 4),
+                                          ),
+                                        ],
+                                      ),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            news.title ?? "제목 없음",
+                                            style: const TextStyle(
+                                              fontSize: 18,
+                                              fontWeight: FontWeight.bold,
                                             ),
                                           ),
-                                        ),
-                                        GestureDetector(
-                                          onTap: () => controller
-                                              .toggleBookmark(article.id),
-                                          child: Obx(() {
-                                            return Image.asset(
-                                              article.isBookmarked.value
-                                                  ? 'assets/bookmark_selected.png' // 북마크 활성 상태
-                                                  : 'assets/bookmark.png', // 북마크 비활성 상태
-                                              width: 13,
-                                              height: 18.38,
-                                            );
-                                          }),
-                                        ),
-                                      ],
-                                    ),
-                                    const SizedBox(
-                                      height: 6,
-                                    ),
-                                    Row(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.spaceBetween,
-                                      children: [
-                                        // 신문사
-                                        Text(
-                                          article.publisher,
-                                          style: const TextStyle(
-                                            color: Color(0xFF767676),
-                                            fontSize: 12,
-                                            fontWeight: FontWeight.w400,
-                                            height: 1.50,
-                                            letterSpacing: -0.30,
+                                          const SizedBox(height: 8),
+                                          Text(
+                                            news.content ?? "내용 없음",
+                                            style:
+                                                const TextStyle(fontSize: 14),
                                           ),
-                                        ),
-                                        // 기사 업로드 시간
-                                        Text(
-                                          article.uploadTime,
-                                          style: const TextStyle(
-                                            color: Color(0xFF767676),
-                                            fontSize: 12,
-                                            fontWeight: FontWeight.w400,
-                                            height: 1.50,
-                                            letterSpacing: -0.30,
+                                          const SizedBox(height: 8),
+                                          Text(
+                                            "출처: ${news.publisher ?? "알 수 없음"}",
+                                            style: const TextStyle(
+                                                color: Colors.grey),
                                           ),
-                                        ),
-                                      ],
+                                        ],
+                                      ),
                                     ),
-                                  ],
-                                ),
-                              );
-                            } else {
-                              // 최신순
-                              return const SizedBox();
-                            }
-                          },
-                          separatorBuilder: (context, index) {
-                            return Padding(
-                              padding: const EdgeInsets.symmetric(vertical: 16),
-                              child: Container(
-                                height: 1,
-                                color: const Color(0xffd9d9d9),
+                                  );
+                                },
                               ),
-                            ); // 항목 사이에 구분선 추가
+                            );
                           },
-                        ),
-                      ),
+                        );
+                      })
+                      // Expanded(
+                      //   child: ListView.separated(
+                      //     shrinkWrap: true,
+                      //     itemCount: controller.articles.length, // 예시 데이터 갯수
+                      //     itemBuilder: (context, index) {
+                      //       final article = controller.articles[index];
+                      //       // 인기순과 최신순을 구분해서 데이터를 다르게 처리
+                      //       if (controller.selectedOrder.value == 0) {
+                      //         // 인기순
+                      //         return Padding(
+                      //           padding: const EdgeInsets.all(16),
+                      //           child: Column(
+                      //             crossAxisAlignment: CrossAxisAlignment.start,
+                      //             children: [
+                      //               // 카테고리 이름
+                      //               Text(
+                      //                 article.category,
+                      //                 style: const TextStyle(
+                      //                   color: Color(0xFF2AD6D6),
+                      //                   fontSize: 12,
+                      //                   fontWeight: FontWeight.w600,
+                      //                   height: 1.30,
+                      //                   letterSpacing: -0.30,
+                      //                 ),
+                      //               ),
+                      //               const SizedBox(
+                      //                 height: 6,
+                      //               ),
+
+                      //               Row(
+                      //                 mainAxisAlignment:
+                      //                     MainAxisAlignment.spaceBetween,
+                      //                 crossAxisAlignment:
+                      //                     CrossAxisAlignment.start,
+                      //                 children: [
+                      //                   // 기사 헤드라인
+                      //                   GestureDetector(
+                      //                     onTap: () {
+                      //                       controller.toDetailPage(article);
+                      //                     },
+                      //                     child: SizedBox(
+                      //                       width: MediaQuery.of(context)
+                      //                               .size
+                      //                               .width -
+                      //                           80,
+                      //                       child: Text(
+                      //                         article.headline,
+                      //                         style: const TextStyle(
+                      //                           color: Color(0xFF111111),
+                      //                           fontSize: 16,
+                      //                           fontWeight: FontWeight.w500,
+                      //                           height: 1.30,
+                      //                           letterSpacing: -0.40,
+                      //                         ),
+                      //                       ),
+                      //                     ),
+                      //                   ),
+                      //                   GestureDetector(
+                      //                     onTap: () => controller
+                      //                         .toggleBookmark(article.id),
+                      //                     child: Obx(() {
+                      //                       return Image.asset(
+                      //                         article.isBookmarked.value
+                      //                             ? 'assets/bookmark_selected.png' // 북마크 활성 상태
+                      //                             : 'assets/bookmark.png', // 북마크 비활성 상태
+                      //                         width: 13,
+                      //                         height: 18.38,
+                      //                       );
+                      //                     }),
+                      //                   ),
+                      //                 ],
+                      //               ),
+                      //               const SizedBox(
+                      //                 height: 6,
+                      //               ),
+                      //               Row(
+                      //                 mainAxisAlignment:
+                      //                     MainAxisAlignment.spaceBetween,
+                      //                 children: [
+                      //                   // 신문사
+                      //                   Text(
+                      //                     article.publisher,
+                      //                     style: const TextStyle(
+                      //                       color: Color(0xFF767676),
+                      //                       fontSize: 12,
+                      //                       fontWeight: FontWeight.w400,
+                      //                       height: 1.50,
+                      //                       letterSpacing: -0.30,
+                      //                     ),
+                      //                   ),
+                      //                   // 기사 업로드 시간
+                      //                   Text(
+                      //                     article.uploadTime,
+                      //                     style: const TextStyle(
+                      //                       color: Color(0xFF767676),
+                      //                       fontSize: 12,
+                      //                       fontWeight: FontWeight.w400,
+                      //                       height: 1.50,
+                      //                       letterSpacing: -0.30,
+                      //                     ),
+                      //                   ),
+                      //                 ],
+                      //               ),
+                      //             ],
+                      //           ),
+                      //         );
+                      //       } else {
+                      //         // 최신순
+                      //         return const SizedBox();
+                      //       }
+                      //     },
+                      //     separatorBuilder: (context, index) {
+                      //       return Padding(
+                      //         padding: const EdgeInsets.symmetric(vertical: 16),
+                      //         child: Container(
+                      //           height: 1,
+                      //           color: const Color(0xffd9d9d9),
+                      //         ),
+                      //       ); // 항목 사이에 구분선 추가
+                      //     },
+                      //   ),
+                      // ),
                     ],
                   ),
                 );

--- a/economic_fe/lib/view/screens/article/article_list_page.dart
+++ b/economic_fe/lib/view/screens/article/article_list_page.dart
@@ -20,7 +20,7 @@ class _ArticleListPageState extends State<ArticleListPage> {
   void initState() {
     // TODO: implement initState
     super.initState();
-    controller.getNewsList(1, "RECENT", "FINANCE");
+    controller.getNewsList(1, "RECENT", null);
   }
 
   @override
@@ -53,74 +53,104 @@ class _ArticleListPageState extends State<ArticleListPage> {
                   scrollDirection: Axis.horizontal,
                   children: [
                     GestureDetector(
-                      onTap: () => controller.selectCategory(0),
+                      onTap: () {
+                        controller.selectCategory(0);
+                        controller.getNewsList(1, "RECENT", null);
+                      },
                       child: CategoryTab(
                         isSelected: controller.selectedCategoryIndex.value == 0,
                         text: '전체',
                       ),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(1),
+                      onTap: () {
+                        controller.selectCategory(1);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 1,
-                          text: '경기 분석'),
+                          text: 'FINANCE'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(2),
+                      onTap: () {
+                        controller.selectCategory(2);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 2,
-                          text: '경제 일반'),
+                          text: 'INVESTMENT'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(3),
+                      onTap: () {
+                        controller.selectCategory(3);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 3,
-                          text: '금융'),
+                          text: 'NORMAL'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(4),
+                      onTap: () {
+                        controller.selectCategory(4);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 4,
-                          text: '국제경제'),
+                          text: 'GLOBAL'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(5),
+                      onTap: () {
+                        controller.selectCategory(5);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 5,
-                          text: '부동산'),
+                          text: 'INDUSTRY'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(6),
+                      onTap: () {
+                        controller.selectCategory(6);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 6,
-                          text: '산업경제'),
+                          text: 'REAL_ESTATE'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(7),
+                      onTap: () {
+                        controller.selectCategory(7);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 7,
-                          text: '정부와 경제 정책'),
+                          text: 'ECONOMIC_ANALYSIS'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(8),
+                      onTap: () {
+                        controller.selectCategory(8);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 8,
-                          text: '투자'),
+                          text: 'ECONOMIC_POLICY'),
                     ),
                     GestureDetector(
-                      onTap: () => controller.selectCategory(9),
+                      onTap: () {
+                        controller.selectCategory(9);
+                        controller.getNewsList(1, "RECENT", "FINANCE");
+                      },
                       child: CategoryTab(
                           isSelected:
                               controller.selectedCategoryIndex.value == 9,
-                          text: '기타'),
+                          text: 'OTHER'),
                     ),
                   ],
                 );
@@ -142,7 +172,9 @@ class _ArticleListPageState extends State<ArticleListPage> {
                           children: [
                             // 인기순/최신순 선택
                             GestureDetector(
-                              onTap: () => controller.selectOrder(0),
+                              onTap: () {
+                                controller.selectOrder(0);
+                              },
                               child: OrderTab(
                                 text: '인기순',
                                 isSelected: controller.selectedOrder.value == 0,
@@ -152,7 +184,9 @@ class _ArticleListPageState extends State<ArticleListPage> {
                               width: 6,
                             ),
                             GestureDetector(
-                              onTap: () => controller.selectOrder(1),
+                              onTap: () {
+                                controller.selectOrder(1);
+                              },
                               child: OrderTab(
                                 text: '최신순',
                                 isSelected: controller.selectedOrder.value == 1,

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -1,10 +1,14 @@
 import 'package:economic_fe/data/models/article.dart';
+import 'package:economic_fe/data/models/article_model.dart';
 import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:economic_fe/view/screens/article/article_detail_page.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class ArticleListController extends GetxController {
+  var selectedCate = "FINANCE".obs;
+  var selectedSort = "RECENT".obs;
+
   // 현재 선택된 카테고리 인덱스
   Rx<int> selectedCategoryIndex = 0.obs;
 
@@ -53,7 +57,8 @@ class ArticleListController extends GetxController {
   }
 
   //뉴스 기사 목록 불러오기
-  Future<void> getNewsList(int page, String sort, String? category) async {
+  Future<List<ArticleModel>> getNewsList(
+      int page, String sort, String? category) async {
     try {
       print("start");
       dynamic response;
@@ -69,14 +74,18 @@ class ArticleListController extends GetxController {
       print(response);
       final data = response as Map<String, dynamic>;
       final newsList = data['results']['newsList'] as List;
-      print(newsList);
-
-      for (final news in newsList) {
-        final title = news['title'];
-        print("뉴스 제목 : $title");
-      }
+      // print(newsList);
+      print("Ddd");
+      print(newsList.map((news) => ArticleModel.fromJson(news)).toList());
+      return newsList.map((news) => ArticleModel.fromJson(news)).toList();
+      // for (final news in newsList) {
+      //   // final title = news['title'];
+      //   // print("뉴스 제목 : $title");
+      //   ArticleModel.fromJson(news);
+      // }
     } catch (e) {
       debugPrint('Error: $e');
+      return [];
     }
   }
 }

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -7,7 +7,7 @@ import 'package:get/get.dart';
 
 class ArticleListController extends GetxController {
   var selectedSort = "RECENT".obs; //
-  var selectedCate = "FINANCE".obs;
+  var selectedCate = "전체".obs;
 
   // 현재 선택된 카테고리 인덱스
   Rx<int> selectedCategoryIndex = 0.obs;
@@ -72,12 +72,12 @@ class ArticleListController extends GetxController {
         print("n : $response");
       }
 
-      print(response);
+      // print(response);
       final data = response as Map<String, dynamic>;
       final newsList = data['results']['newsList'] as List;
       // print(newsList);
-      print("Ddd");
-      print(newsList.map((news) => ArticleModel.fromJson(news)).toList());
+      // print("Ddd");
+      // print(newsList.map((news) => ArticleModel.fromJson(news)).toList());
       return newsList.map((news) => ArticleModel.fromJson(news)).toList();
       // for (final news in newsList) {
       //   // final title = news['title'];

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -1,5 +1,7 @@
 import 'package:economic_fe/data/models/article.dart';
+import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:economic_fe/view/screens/article/article_detail_page.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class ArticleListController extends GetxController {
@@ -48,5 +50,17 @@ class ArticleListController extends GetxController {
   // 챗봇 화면으로 이동
   void toChatbot() {
     Get.toNamed('/chatbot');
+  }
+
+  //뉴스 기사 목록 불러오기
+  Future<void> getNewsList(int page, String sort, String category) async {
+    try {
+      print("start");
+      dynamic response =
+          await RemoteDataSource.getNewsList(page, sort, category);
+      print(response);
+    } catch (e) {
+      debugPrint('Error: $e');
+    }
   }
 }

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -53,12 +53,28 @@ class ArticleListController extends GetxController {
   }
 
   //뉴스 기사 목록 불러오기
-  Future<void> getNewsList(int page, String sort, String category) async {
+  Future<void> getNewsList(int page, String sort, String? category) async {
     try {
       print("start");
-      dynamic response =
-          await RemoteDataSource.getNewsList(page, sort, category);
+      dynamic response;
+
+      if (category != null) {
+        response = await RemoteDataSource.getNewsList(page, sort, category);
+        print("null : $response");
+      } else {
+        response = await RemoteDataSource.getNewsList(page, sort, null);
+        print("null아님 : $response");
+      }
+
       print(response);
+      final data = response as Map<String, dynamic>;
+      final newsList = data['results']['newsList'] as List;
+      print(newsList);
+
+      for (final news in newsList) {
+        final title = news['title'];
+        print("뉴스 제목 : $title");
+      }
     } catch (e) {
       debugPrint('Error: $e');
     }

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -6,15 +6,16 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class ArticleListController extends GetxController {
+  var selectedSort = "RECENT".obs; //
   var selectedCate = "FINANCE".obs;
-  var selectedSort = "RECENT".obs;
 
   // 현재 선택된 카테고리 인덱스
   Rx<int> selectedCategoryIndex = 0.obs;
 
   // 카테고리 탭 클릭 시 선택된 카테고리 인덱스 업데이트
-  void selectCategory(int index) {
-    selectedCategoryIndex.value = index;
+  void selectCategory(String index) {
+    // selectedCategoryIndex.value = idx;
+    selectedCate.value = index;
   }
 
   // 인기순 / 최신순 선택 상태 관리
@@ -41,7 +42,7 @@ class ArticleListController extends GetxController {
   );
 
   // 기사 세부페이지로 이동
-  void toDetailPage(Article article) {
+  void toDetailPage(ArticleModel article) {
     Get.to(() => const ArticleDetailPage(), arguments: article);
   }
 
@@ -65,10 +66,10 @@ class ArticleListController extends GetxController {
 
       if (category != null) {
         response = await RemoteDataSource.getNewsList(page, sort, category);
-        print("null : $response");
-      } else {
+        print("n   $response");
+      } else if (category == null || selectedCate == "전체") {
         response = await RemoteDataSource.getNewsList(page, sort, null);
-        print("null아님 : $response");
+        print("n : $response");
       }
 
       print(response);

--- a/economic_fe/lib/view_model/learning_set/learning_list_controller.dart
+++ b/economic_fe/lib/view_model/learning_set/learning_list_controller.dart
@@ -46,10 +46,10 @@ class LearningListController extends GetxController {
 
   Future<void> getLearningConcept(int learningSetId, String level) async {
     try {
-      print("start");
+      // print("start");
       dynamic response =
           await RemoteDataSource.getLearningConcept(learningSetId, level);
-      print("출력");
+      // print("출력");
       print(response);
     } catch (e) {
       debugPrint('Error: $e');

--- a/economic_fe/pubspec.lock
+++ b/economic_fe/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -380,18 +380,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -580,7 +580,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -593,10 +593,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -737,10 +737,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] GET API 함수 header로 accessToken 넣어야하는 경우 따로 생성
- [x] 상단 탭으로 카테고리 전환 후 뉴스 목록 조회 구현
- [x] 최신순/인기순 조회 구현 
- [ ] 백엔드 스크랩 추가 이후 스크랩 UI 수정 예정
- [ ] "전체" 탭 조회 수정 예정  

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<table><tr>
<td><img src="https://github.com/user-attachments/assets/5c5ac072-2408-4ba0-ace3-71c5a8f4bc80" width="300"></td>
<td><img src="https://github.com/user-attachments/assets/b500ae36-c1c2-409c-96c1-8cfad2b81041" width="300"></td>
<td><img src="https://github.com/user-attachments/assets/3159bf05-78e1-4d82-8e67-fa3599e4127b" width="300"></td>
<td><img src="https://github.com/user-attachments/assets/0c4bec46-c67f-463f-8a4f-ec751ebafa53" width="300"></td>
</tr></table>

