### PR TITLE
feat: 용어사전 api 연동 완료

### DIFF
--- a/economic_fe/lib/data/models/dictionary_model.dart
+++ b/economic_fe/lib/data/models/dictionary_model.dart
@@ -1,0 +1,26 @@
+// 뉴스 모델
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class DictionaryModel with ChangeNotifier {
+  int? termId;
+  String? termName;
+  String? termDescription;
+
+  DictionaryModel({
+    this.termId,
+    this.termName,
+    this.termDescription,
+  });
+
+  factory DictionaryModel.fromJson(Map<String, dynamic> json) {
+    return DictionaryModel(
+      termId: json['termId'],
+      termName: json['termName'],
+      termDescription: json['termDescription'],
+    );
+  }
+}

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -212,4 +212,20 @@ class RemoteDataSource {
     }
     return response;
   }
+
+  /// 용어 상세 조회
+  /// api/v1/terms/{id}
+  static Future<dynamic> getDetailTerms(int id) async {
+    dynamic response;
+
+    response = await _getApiWithHeader('api/v1/terms/$id', accessToken);
+
+    if (response != null) {
+      print("용어 상세 : $response");
+    } else {
+      print("get 데이터 실패");
+    }
+
+    return response;
+  }
 }

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -228,4 +228,25 @@ class RemoteDataSource {
 
     return response;
   }
+
+  /// 키워드 별 용어 조회
+  /// api/v1/terms/search/keyword
+  static Future<dynamic> getKewordResult(int page, String keyword) async {
+    dynamic response;
+
+    // 한글을 URL 인코딩
+    String encodedkeyword = Uri.encodeComponent(keyword);
+
+    response = await _getApiWithHeader(
+        'api/v1/terms/search/keyword?page=$page&keyword=$encodedkeyword',
+        accessToken);
+
+    if (response != null) {
+      print("키워드 검색 결과 : $response");
+    } else {
+      print("get 데이터 실패");
+    }
+
+    return response;
+  }
 }

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -170,7 +170,6 @@ class RemoteDataSource {
 
   /// 뉴스 목록 조회
   /// api/news
-
   static Future<dynamic> getNewsList(
       int page, String sort, String? category) async {
     dynamic response;
@@ -190,6 +189,26 @@ class RemoteDataSource {
       print('응답 데이터 : $response');
     } else {
       print('데이터 get 실패');
+    }
+    return response;
+  }
+
+  /// 자음 별 용어 조회
+  /// api/v1/terms/search/consonant
+  static Future<dynamic> getDictionary(int page, String consonant) async {
+    dynamic response;
+
+    // 한글 자음을 URL 인코딩
+    String encodedConsonant = Uri.encodeComponent(consonant);
+
+    response = await _getApiWithHeader(
+        'api/v1/terms/search/consonant?page=$page&consonant=$encodedConsonant',
+        accessToken);
+
+    if (response != null) {
+      print("용어사전 응답 데이터 : $response");
+    } else {
+      print("get 데이터 실패");
     }
     return response;
   }

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/article',
+      initialRoute: '/dictionary',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/view/screens/article/article_detail_page.dart
+++ b/economic_fe/lib/view/screens/article/article_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:economic_fe/data/models/article.dart';
+import 'package:economic_fe/data/models/article_model.dart';
 import 'package:economic_fe/view/theme/palette.dart';
 import 'package:economic_fe/view/widgets/chatbot_fab.dart';
 import 'package:economic_fe/view/widgets/custom_app_bar.dart';
@@ -18,7 +19,7 @@ class _ArticleDetailPageState extends State<ArticleDetailPage> {
   late WebViewController webViewController;
   final ArticleDetailController controller = Get.put(ArticleDetailController());
   // 전달받은 기사 데이터
-  final Article article = Get.arguments as Article;
+  final ArticleModel article = Get.arguments as ArticleModel;
 
   @override
   void initState() {
@@ -34,7 +35,7 @@ class _ArticleDetailPageState extends State<ArticleDetailPage> {
       backgroundColor: Palette.background,
       appBar: CustomAppBar(
         icon: Icons.arrow_back_ios_new,
-        title: article.headline,
+        title: truncateWithEllipsis(article.title ?? "", 15),
         onPress: () {
           controller.goBack();
         },
@@ -50,5 +51,11 @@ class _ArticleDetailPageState extends State<ArticleDetailPage> {
         height: 34,
       ),
     );
+  }
+
+  String truncateWithEllipsis(String text, int maxLength) {
+    return (text.length > maxLength)
+        ? '${text.substring(0, maxLength)}...'
+        : text;
   }
 }

--- a/economic_fe/lib/view/screens/article/article_list_page.dart
+++ b/economic_fe/lib/view/screens/article/article_list_page.dart
@@ -258,13 +258,18 @@ class _ArticleListPageState extends State<ArticleListPage> {
                                               height: 1.3,
                                             ),
                                           ),
-                                          Text(
-                                            news.title ?? "제목 없음",
-                                            style: const TextStyle(
-                                              fontSize: 16,
-                                              fontWeight: FontWeight.w500,
-                                              height: 1.3,
-                                              letterSpacing: -0.4,
+                                          GestureDetector(
+                                            onTap: () {
+                                              controller.toDetailPage(news);
+                                            },
+                                            child: Text(
+                                              news.title ?? "제목 없음",
+                                              style: const TextStyle(
+                                                fontSize: 16,
+                                                fontWeight: FontWeight.w500,
+                                                height: 1.3,
+                                                letterSpacing: -0.4,
+                                              ),
                                             ),
                                           ),
                                           const SizedBox(height: 6),

--- a/economic_fe/lib/view/screens/dictionary_page.dart
+++ b/economic_fe/lib/view/screens/dictionary_page.dart
@@ -270,6 +270,7 @@ class _DictionaryPageState extends State<DictionaryPage> {
             //     },
             //   ),
             // ),
+
             Obx(() {
               return FutureBuilder<List<DictionaryModel>>(
                 future: controller.getDictionaryList(
@@ -303,72 +304,176 @@ class _DictionaryPageState extends State<DictionaryPage> {
                         final terms = termList[index];
                         return Column(
                           children: [
-                            Container(
-                              margin: const EdgeInsets.symmetric(vertical: 8),
-                              padding: const EdgeInsets.all(16),
-                              decoration: const BoxDecoration(
-                                color: Colors.white,
-                              ),
-                              child: Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  SizedBox(
-                                    child: Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          // items[index]['word']!, // 단어 표시
-                                          terms.termName ?? "",
-                                          style: const TextStyle(
-                                              fontSize: 16,
-                                              fontWeight: FontWeight.w500,
-                                              color:
-                                                  Color.fromARGB(255, 0, 0, 0),
-                                              height: 1.4,
-                                              letterSpacing: -0.4),
-                                        ),
-                                        const SizedBox(
-                                            height: 8), // 단어와 설명 간 간격
-                                        Text(
-                                          // items[index]['description'] ??
-                                          //     "설명이 없습니다",
-                                          terms.termDescription ?? "",
-                                          style: const TextStyle(
-                                            fontSize: 14,
-                                            color: Color(0xFF767676),
-                                            fontWeight: FontWeight.w400,
-                                            height: 1.4,
-                                            letterSpacing: -0.35,
+                            GestureDetector(
+                              onTap: () {
+                                // termId가 없을 경우 2로 대체
+                                controller.getTermDetail(terms.termId ?? 2);
+
+                                // 상세 보기
+                                showDialog(
+                                  context: context,
+                                  builder: (BuildContext context) {
+                                    return Dialog(
+                                      backgroundColor: Colors.white,
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(
+                                            10), // 팝업 테두리 둥글게
+                                      ),
+                                      child: Stack(
+                                        children: [
+                                          Padding(
+                                            padding: const EdgeInsets.all(16.0),
+                                            child: Column(
+                                              mainAxisSize: MainAxisSize.min,
+                                              crossAxisAlignment:
+                                                  CrossAxisAlignment.start,
+                                              children: [
+                                                const SizedBox(
+                                                  height: 14,
+                                                ),
+                                                // 제목
+                                                Text(
+                                                  terms.termName ?? "용어 제목",
+                                                  style: const TextStyle(
+                                                    fontSize: 18,
+                                                    fontWeight: FontWeight.w600,
+                                                    letterSpacing: -0.45,
+                                                    height: 1.2,
+                                                  ),
+                                                ),
+                                                const SizedBox(height: 12),
+                                                // 내용
+                                                Text(
+                                                  terms.termDescription ??
+                                                      "상세 내용이 없습니다.",
+                                                  style: const TextStyle(
+                                                    fontSize: 14,
+                                                    color: Colors.black87,
+                                                  ),
+                                                ),
+                                                const SizedBox(height: 16),
+                                                // 하단 버튼
+                                                // Row(
+                                                //   mainAxisAlignment:
+                                                //       MainAxisAlignment.end,
+                                                //   children: [
+                                                //     TextButton(
+                                                //       onPressed: () {
+                                                //         Navigator.of(context)
+                                                //             .pop(); // 팝업 닫기
+                                                //       },
+                                                //       child: const Text("닫기"),
+                                                //     ),
+                                                //     TextButton(
+                                                //       onPressed: () {
+                                                //         // 추가 동작 수행
+                                                //         print('추가 동작 수행');
+                                                //         Navigator.of(context)
+                                                //             .pop(); // 팝업 닫기
+                                                //       },
+                                                //       child: const Text("확인"),
+                                                //     ),
+                                                //   ],
+                                                // ),
+                                              ],
+                                            ),
                                           ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                  GestureDetector(
-                                    onTap: () {
-                                      setState(() {
-                                        // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
-                                        items[index]['selectedWord'] =
-                                            !(items[index]['selectedWord'] ??
-                                                false);
-                                        // print("Dd");
-                                      });
-                                    },
-                                    child: Padding(
-                                      padding: const EdgeInsets.only(
-                                          left: 11, top: 8, bottom: 8),
-                                      child: Image.asset(
-                                        items[index]['selectedWord'] ?? false
-                                            ? "assets/bookmark_selected.png"
-                                            : "assets/bookmark.png",
-                                        width: 13,
-                                        height: 18.2,
+                                          // 오른쪽쪽 위 X 버튼
+                                          Positioned(
+                                            top: 8,
+                                            right: 8,
+                                            child: GestureDetector(
+                                              onTap: () {
+                                                Navigator.of(context)
+                                                    .pop(); // 팝업 닫기
+                                              },
+                                              child: const Icon(
+                                                Icons.close,
+                                                color: Colors.black,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    );
+                                  },
+                                );
+                              },
+                              child: Container(
+                                margin: const EdgeInsets.symmetric(vertical: 8),
+                                padding: const EdgeInsets.all(16),
+                                decoration: const BoxDecoration(
+                                  color: Colors.white,
+                                ),
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    SizedBox(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            // items[index]['word']!, // 단어 표시
+                                            // terms.termName ?? "",
+                                            truncateWithEllipsis(
+                                                terms.termName ?? "", 20),
+                                            style: const TextStyle(
+                                                fontSize: 16,
+                                                fontWeight: FontWeight.w500,
+                                                color: Color.fromARGB(
+                                                    255, 0, 0, 0),
+                                                height: 1.4,
+                                                letterSpacing: -0.4),
+                                          ),
+                                          const SizedBox(
+                                              height: 8), // 단어와 설명 간 간격
+                                          SizedBox(
+                                            width: 300,
+                                            child: Text(
+                                              // items[index]['description'] ??
+                                              //     "설명이 없습니다",
+                                              // terms.termDescription ?? "",
+                                              truncateWithEllipsis(
+                                                  terms.termDescription ?? "",
+                                                  25),
+                                              style: const TextStyle(
+                                                fontSize: 14,
+                                                color: Color(0xFF767676),
+                                                fontWeight: FontWeight.w400,
+                                                height: 1.4,
+                                                letterSpacing: -0.35,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
                                       ),
                                     ),
-                                  )
-                                ],
+                                    // GestureDetector(
+                                    //   onTap: () {
+                                    //     setState(() {
+                                    //       // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
+                                    //       items[index]['selectedWord'] =
+                                    //           !(items[index]['selectedWord'] ??
+                                    //               false);
+                                    //       // print("Dd");
+                                    //     });
+                                    //   },
+                                    //   child: Padding(
+                                    //     padding: const EdgeInsets.only(
+                                    //         left: 11, top: 8, bottom: 8),
+                                    //     child: Image.asset(
+                                    //       items[index]['selectedWord'] ?? false
+                                    //           ? "assets/bookmark_selected.png"
+                                    //           : "assets/bookmark.png",
+                                    //       width: 13,
+                                    //       height: 18.2,
+                                    //     ),
+                                    //   ),
+                                    // )
+                                  ],
+                                ),
                               ),
                             ),
                             if (index !=
@@ -483,5 +588,12 @@ class _DictionaryPageState extends State<DictionaryPage> {
         );
       },
     );
+  }
+
+  // 길이 제한 함수
+  String truncateWithEllipsis(String text, int maxLength) {
+    return (text.length > maxLength)
+        ? '${text.substring(0, maxLength)}...'
+        : text;
   }
 }

--- a/economic_fe/lib/view/screens/dictionary_page.dart
+++ b/economic_fe/lib/view/screens/dictionary_page.dart
@@ -144,6 +144,14 @@ class _DictionaryPageState extends State<DictionaryPage> {
                 print(controller.keyword.value);
                 controller.typeValue.value = false;
                 controller.getKewordResult(0, controller.keyword.value);
+                // controller.getDictionaryList(
+                //     1,
+                //     controller.typeValue.value
+                //         ? controller.selectedConsonant.value
+                //         : controller.keyword.value,
+                //     controller.typeValue.value);
+                print("검색ㅇㅇㅇㅇㅇㅇ");
+                print(controller.typeValue.value);
               },
               child: const Text("검색"),
             ),
@@ -164,6 +172,7 @@ class _DictionaryPageState extends State<DictionaryPage> {
                               controller.selectedConsonant.value =
                                   consonants[index];
                               print(controller.selectedConsonant.value);
+                              controller.typeValue.value = true;
                             });
                           },
                           child: Container(
@@ -284,231 +293,485 @@ class _DictionaryPageState extends State<DictionaryPage> {
             //     },
             //   ),
             // ),
+            controller.typeValue.value
+                ? Obx(() {
+                    return FutureBuilder<List<DictionaryModel>>(
+                      future: controller.getDictionaryList(
+                          0,
+                          controller.typeValue.value
+                              ? controller.selectedConsonant.value
+                              : controller.keyword.value,
+                          controller.typeValue.value),
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Center(
+                            child: CircularProgressIndicator(),
+                          );
+                        }
 
-            Obx(() {
-              return FutureBuilder<List<DictionaryModel>>(
-                future: controller.getDictionaryList(
-                    1,
-                    controller.typeValue.value
-                        ? controller.selectedConsonant.value
-                        : controller.keyword.value,
-                    controller.typeValue.value),
-                builder: (context, snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return const Center(
-                      child: CircularProgressIndicator(),
-                    );
-                  }
+                        // 에러인 경우
+                        if (snapshot.hasError) {
+                          return Center(
+                            child: Text("에러 발생 : ${snapshot.error}"),
+                          );
+                        }
 
-                  // 에러인 경우
-                  if (snapshot.hasError) {
-                    return Center(
-                      child: Text("에러 발생 : ${snapshot.error}"),
-                    );
-                  }
+                        // 데이터가 없을 때
+                        if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                          return const Center(
+                            child: Text("용어 사전 데이터가 없습니다."),
+                          );
+                        }
+                        final termList = snapshot.data!;
 
-                  // 데이터가 없을 때
-                  if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                    return const Center(
-                      child: Text("용어 사전 데이터가 없습니다."),
-                    );
-                  }
-                  final termList = snapshot.data!;
+                        return Expanded(
+                          child: ListView.builder(
+                            itemCount: termList.length,
+                            itemBuilder: (context, index) {
+                              final terms = termList[index];
+                              return Column(
+                                children: [
+                                  GestureDetector(
+                                    onTap: () {
+                                      // termId가 없을 경우 2로 대체
+                                      controller
+                                          .getTermDetail(terms.termId ?? 2);
 
-                  return Expanded(
-                    child: ListView.builder(
-                      itemCount: termList.length,
-                      itemBuilder: (context, index) {
-                        final terms = termList[index];
-                        return Column(
-                          children: [
-                            GestureDetector(
-                              onTap: () {
-                                // termId가 없을 경우 2로 대체
-                                controller.getTermDetail(terms.termId ?? 2);
-
-                                // 상세 보기
-                                showDialog(
-                                  context: context,
-                                  builder: (BuildContext context) {
-                                    return Dialog(
-                                      backgroundColor: Colors.white,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(
-                                            10), // 팝업 테두리 둥글게
+                                      // 상세 보기
+                                      showDialog(
+                                        context: context,
+                                        builder: (BuildContext context) {
+                                          return Dialog(
+                                            backgroundColor: Colors.white,
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(
+                                                      10), // 팝업 테두리 둥글게
+                                            ),
+                                            child: Stack(
+                                              children: [
+                                                Padding(
+                                                  padding: const EdgeInsets.all(
+                                                      16.0),
+                                                  child: Column(
+                                                    mainAxisSize:
+                                                        MainAxisSize.min,
+                                                    crossAxisAlignment:
+                                                        CrossAxisAlignment
+                                                            .start,
+                                                    children: [
+                                                      const SizedBox(
+                                                        height: 14,
+                                                      ),
+                                                      // 제목
+                                                      Text(
+                                                        terms.termName ??
+                                                            "용어 제목",
+                                                        style: const TextStyle(
+                                                          fontSize: 18,
+                                                          fontWeight:
+                                                              FontWeight.w600,
+                                                          letterSpacing: -0.45,
+                                                          height: 1.2,
+                                                        ),
+                                                      ),
+                                                      const SizedBox(
+                                                          height: 12),
+                                                      // 내용
+                                                      Text(
+                                                        terms.termDescription ??
+                                                            "상세 내용이 없습니다.",
+                                                        style: const TextStyle(
+                                                          fontSize: 14,
+                                                          color: Colors.black87,
+                                                        ),
+                                                      ),
+                                                      const SizedBox(
+                                                          height: 16),
+                                                      // 하단 버튼
+                                                      // Row(
+                                                      //   mainAxisAlignment:
+                                                      //       MainAxisAlignment.end,
+                                                      //   children: [
+                                                      //     TextButton(
+                                                      //       onPressed: () {
+                                                      //         Navigator.of(context)
+                                                      //             .pop(); // 팝업 닫기
+                                                      //       },
+                                                      //       child: const Text("닫기"),
+                                                      //     ),
+                                                      //     TextButton(
+                                                      //       onPressed: () {
+                                                      //         // 추가 동작 수행
+                                                      //         print('추가 동작 수행');
+                                                      //         Navigator.of(context)
+                                                      //             .pop(); // 팝업 닫기
+                                                      //       },
+                                                      //       child: const Text("확인"),
+                                                      //     ),
+                                                      //   ],
+                                                      // ),
+                                                    ],
+                                                  ),
+                                                ),
+                                                // 오른쪽쪽 위 X 버튼
+                                                Positioned(
+                                                  top: 8,
+                                                  right: 8,
+                                                  child: GestureDetector(
+                                                    onTap: () {
+                                                      Navigator.of(context)
+                                                          .pop(); // 팝업 닫기
+                                                    },
+                                                    child: const Icon(
+                                                      Icons.close,
+                                                      color: Colors.black,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
+                                          );
+                                        },
+                                      );
+                                    },
+                                    child: Container(
+                                      margin: const EdgeInsets.symmetric(
+                                          vertical: 8),
+                                      padding: const EdgeInsets.all(16),
+                                      decoration: const BoxDecoration(
+                                        color: Colors.white,
                                       ),
-                                      child: Stack(
+                                      child: Row(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.spaceBetween,
                                         children: [
-                                          Padding(
-                                            padding: const EdgeInsets.all(16.0),
+                                          SizedBox(
                                             child: Column(
-                                              mainAxisSize: MainAxisSize.min,
                                               crossAxisAlignment:
                                                   CrossAxisAlignment.start,
                                               children: [
+                                                Text(
+                                                  // items[index]['word']!, // 단어 표시
+                                                  // terms.termName ?? "",
+                                                  truncateWithEllipsis(
+                                                      terms.termName ?? "", 20),
+                                                  style: const TextStyle(
+                                                      fontSize: 16,
+                                                      fontWeight:
+                                                          FontWeight.w500,
+                                                      color: Color.fromARGB(
+                                                          255, 0, 0, 0),
+                                                      height: 1.4,
+                                                      letterSpacing: -0.4),
+                                                ),
                                                 const SizedBox(
-                                                  height: 14,
-                                                ),
-                                                // 제목
-                                                Text(
-                                                  terms.termName ?? "용어 제목",
-                                                  style: const TextStyle(
-                                                    fontSize: 18,
-                                                    fontWeight: FontWeight.w600,
-                                                    letterSpacing: -0.45,
-                                                    height: 1.2,
+                                                    height: 8), // 단어와 설명 간 간격
+                                                SizedBox(
+                                                  width: 300,
+                                                  child: Text(
+                                                    // items[index]['description'] ??
+                                                    //     "설명이 없습니다",
+                                                    // terms.termDescription ?? "",
+                                                    truncateWithEllipsis(
+                                                        terms.termDescription ??
+                                                            "",
+                                                        25),
+                                                    style: const TextStyle(
+                                                      fontSize: 14,
+                                                      color: Color(0xFF767676),
+                                                      fontWeight:
+                                                          FontWeight.w400,
+                                                      height: 1.4,
+                                                      letterSpacing: -0.35,
+                                                    ),
                                                   ),
                                                 ),
-                                                const SizedBox(height: 12),
-                                                // 내용
-                                                Text(
-                                                  terms.termDescription ??
-                                                      "상세 내용이 없습니다.",
-                                                  style: const TextStyle(
-                                                    fontSize: 14,
-                                                    color: Colors.black87,
-                                                  ),
-                                                ),
-                                                const SizedBox(height: 16),
-                                                // 하단 버튼
-                                                // Row(
-                                                //   mainAxisAlignment:
-                                                //       MainAxisAlignment.end,
-                                                //   children: [
-                                                //     TextButton(
-                                                //       onPressed: () {
-                                                //         Navigator.of(context)
-                                                //             .pop(); // 팝업 닫기
-                                                //       },
-                                                //       child: const Text("닫기"),
-                                                //     ),
-                                                //     TextButton(
-                                                //       onPressed: () {
-                                                //         // 추가 동작 수행
-                                                //         print('추가 동작 수행');
-                                                //         Navigator.of(context)
-                                                //             .pop(); // 팝업 닫기
-                                                //       },
-                                                //       child: const Text("확인"),
-                                                //     ),
-                                                //   ],
-                                                // ),
                                               ],
                                             ),
                                           ),
-                                          // 오른쪽쪽 위 X 버튼
-                                          Positioned(
-                                            top: 8,
-                                            right: 8,
-                                            child: GestureDetector(
-                                              onTap: () {
-                                                Navigator.of(context)
-                                                    .pop(); // 팝업 닫기
-                                              },
-                                              child: const Icon(
-                                                Icons.close,
-                                                color: Colors.black,
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    );
-                                  },
-                                );
-                              },
-                              child: Container(
-                                margin: const EdgeInsets.symmetric(vertical: 8),
-                                padding: const EdgeInsets.all(16),
-                                decoration: const BoxDecoration(
-                                  color: Colors.white,
-                                ),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    SizedBox(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Text(
-                                            // items[index]['word']!, // 단어 표시
-                                            // terms.termName ?? "",
-                                            truncateWithEllipsis(
-                                                terms.termName ?? "", 20),
-                                            style: const TextStyle(
-                                                fontSize: 16,
-                                                fontWeight: FontWeight.w500,
-                                                color: Color.fromARGB(
-                                                    255, 0, 0, 0),
-                                                height: 1.4,
-                                                letterSpacing: -0.4),
-                                          ),
-                                          const SizedBox(
-                                              height: 8), // 단어와 설명 간 간격
-                                          SizedBox(
-                                            width: 300,
-                                            child: Text(
-                                              // items[index]['description'] ??
-                                              //     "설명이 없습니다",
-                                              // terms.termDescription ?? "",
-                                              truncateWithEllipsis(
-                                                  terms.termDescription ?? "",
-                                                  25),
-                                              style: const TextStyle(
-                                                fontSize: 14,
-                                                color: Color(0xFF767676),
-                                                fontWeight: FontWeight.w400,
-                                                height: 1.4,
-                                                letterSpacing: -0.35,
-                                              ),
-                                            ),
-                                          ),
+                                          // GestureDetector(
+                                          //   onTap: () {
+                                          //     setState(() {
+                                          //       // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
+                                          //       items[index]['selectedWord'] =
+                                          //           !(items[index]['selectedWord'] ??
+                                          //               false);
+                                          //       // print("Dd");
+                                          //     });
+                                          //   },
+                                          //   child: Padding(
+                                          //     padding: const EdgeInsets.only(
+                                          //         left: 11, top: 8, bottom: 8),
+                                          //     child: Image.asset(
+                                          //       items[index]['selectedWord'] ?? false
+                                          //           ? "assets/bookmark_selected.png"
+                                          //           : "assets/bookmark.png",
+                                          //       width: 13,
+                                          //       height: 18.2,
+                                          //     ),
+                                          //   ),
+                                          // )
                                         ],
                                       ),
                                     ),
-                                    // GestureDetector(
-                                    //   onTap: () {
-                                    //     setState(() {
-                                    //       // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
-                                    //       items[index]['selectedWord'] =
-                                    //           !(items[index]['selectedWord'] ??
-                                    //               false);
-                                    //       // print("Dd");
-                                    //     });
-                                    //   },
-                                    //   child: Padding(
-                                    //     padding: const EdgeInsets.only(
-                                    //         left: 11, top: 8, bottom: 8),
-                                    //     child: Image.asset(
-                                    //       items[index]['selectedWord'] ?? false
-                                    //           ? "assets/bookmark_selected.png"
-                                    //           : "assets/bookmark.png",
-                                    //       width: 13,
-                                    //       height: 18.2,
-                                    //     ),
-                                    //   ),
-                                    // )
-                                  ],
-                                ),
-                              ),
-                            ),
-                            if (index !=
-                                items.length - 1) // 마지막 항목에는 Divider를 추가하지 않음
-                              const Divider(
-                                color: Color(0xFFEBEBEB), // 디바이더 색상
-                                height: 1, // 높이 설정
-                                thickness: 1, // 두께 설정
-                              ),
-                          ],
+                                  ),
+                                  if (index !=
+                                      items.length -
+                                          1) // 마지막 항목에는 Divider를 추가하지 않음
+                                    const Divider(
+                                      color: Color(0xFFEBEBEB), // 디바이더 색상
+                                      height: 1, // 높이 설정
+                                      thickness: 1, // 두께 설정
+                                    ),
+                                ],
+                              );
+                            },
+                          ),
                         );
                       },
-                    ),
-                  );
-                },
-              );
-            })
+                    );
+                  })
+                : Obx(() {
+                    return FutureBuilder<List<DictionaryModel>>(
+                      future: controller.getDictionaryList(
+                          0,
+                          controller.typeValue.value
+                              ? controller.selectedConsonant.value
+                              : controller.keyword.value,
+                          controller.typeValue.value),
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Center(
+                            child: CircularProgressIndicator(),
+                          );
+                        }
+
+                        // 에러인 경우
+                        if (snapshot.hasError) {
+                          return Center(
+                            child: Text("에러 발생 : ${snapshot.error}"),
+                          );
+                        }
+
+                        // 데이터가 없을 때
+                        if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                          return const Center(
+                            child: Text("용어 사전 데이터가 없습니다."),
+                          );
+                        }
+                        final termList = snapshot.data!;
+
+                        return Expanded(
+                          child: ListView.builder(
+                            itemCount: termList.length,
+                            itemBuilder: (context, index) {
+                              final terms = termList[index];
+                              return Column(
+                                children: [
+                                  GestureDetector(
+                                    onTap: () {
+                                      // termId가 없을 경우 2로 대체
+                                      controller
+                                          .getTermDetail(terms.termId ?? 2);
+
+                                      // 상세 보기
+                                      showDialog(
+                                        context: context,
+                                        builder: (BuildContext context) {
+                                          return Dialog(
+                                            backgroundColor: Colors.white,
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(
+                                                      10), // 팝업 테두리 둥글게
+                                            ),
+                                            child: Stack(
+                                              children: [
+                                                Padding(
+                                                  padding: const EdgeInsets.all(
+                                                      16.0),
+                                                  child: Column(
+                                                    mainAxisSize:
+                                                        MainAxisSize.min,
+                                                    crossAxisAlignment:
+                                                        CrossAxisAlignment
+                                                            .start,
+                                                    children: [
+                                                      const SizedBox(
+                                                        height: 14,
+                                                      ),
+                                                      // 제목
+                                                      Text(
+                                                        terms.termName ??
+                                                            "용어 제목",
+                                                        style: const TextStyle(
+                                                          fontSize: 18,
+                                                          fontWeight:
+                                                              FontWeight.w600,
+                                                          letterSpacing: -0.45,
+                                                          height: 1.2,
+                                                        ),
+                                                      ),
+                                                      const SizedBox(
+                                                          height: 12),
+                                                      // 내용
+                                                      Text(
+                                                        terms.termDescription ??
+                                                            "상세 내용이 없습니다.",
+                                                        style: const TextStyle(
+                                                          fontSize: 14,
+                                                          color: Colors.black87,
+                                                        ),
+                                                      ),
+                                                      const SizedBox(
+                                                          height: 16),
+                                                      // 하단 버튼
+                                                      // Row(
+                                                      //   mainAxisAlignment:
+                                                      //       MainAxisAlignment.end,
+                                                      //   children: [
+                                                      //     TextButton(
+                                                      //       onPressed: () {
+                                                      //         Navigator.of(context)
+                                                      //             .pop(); // 팝업 닫기
+                                                      //       },
+                                                      //       child: const Text("닫기"),
+                                                      //     ),
+                                                      //     TextButton(
+                                                      //       onPressed: () {
+                                                      //         // 추가 동작 수행
+                                                      //         print('추가 동작 수행');
+                                                      //         Navigator.of(context)
+                                                      //             .pop(); // 팝업 닫기
+                                                      //       },
+                                                      //       child: const Text("확인"),
+                                                      //     ),
+                                                      //   ],
+                                                      // ),
+                                                    ],
+                                                  ),
+                                                ),
+                                                // 오른쪽쪽 위 X 버튼
+                                                Positioned(
+                                                  top: 8,
+                                                  right: 8,
+                                                  child: GestureDetector(
+                                                    onTap: () {
+                                                      Navigator.of(context)
+                                                          .pop(); // 팝업 닫기
+                                                    },
+                                                    child: const Icon(
+                                                      Icons.close,
+                                                      color: Colors.black,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
+                                          );
+                                        },
+                                      );
+                                    },
+                                    child: Container(
+                                      margin: const EdgeInsets.symmetric(
+                                          vertical: 8),
+                                      padding: const EdgeInsets.all(16),
+                                      decoration: const BoxDecoration(
+                                        color: Colors.white,
+                                      ),
+                                      child: Row(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.spaceBetween,
+                                        children: [
+                                          SizedBox(
+                                            child: Column(
+                                              crossAxisAlignment:
+                                                  CrossAxisAlignment.start,
+                                              children: [
+                                                Text(
+                                                  // items[index]['word']!, // 단어 표시
+                                                  // terms.termName ?? "",
+                                                  truncateWithEllipsis(
+                                                      terms.termName ?? "", 20),
+                                                  style: const TextStyle(
+                                                      fontSize: 16,
+                                                      fontWeight:
+                                                          FontWeight.w500,
+                                                      color: Color.fromARGB(
+                                                          255, 0, 0, 0),
+                                                      height: 1.4,
+                                                      letterSpacing: -0.4),
+                                                ),
+                                                const SizedBox(
+                                                    height: 8), // 단어와 설명 간 간격
+                                                SizedBox(
+                                                  width: 300,
+                                                  child: Text(
+                                                    // items[index]['description'] ??
+                                                    //     "설명이 없습니다",
+                                                    // terms.termDescription ?? "",
+                                                    truncateWithEllipsis(
+                                                        terms.termDescription ??
+                                                            "",
+                                                        25),
+                                                    style: const TextStyle(
+                                                      fontSize: 14,
+                                                      color: Color(0xFF767676),
+                                                      fontWeight:
+                                                          FontWeight.w400,
+                                                      height: 1.4,
+                                                      letterSpacing: -0.35,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
+                                          ),
+                                          // GestureDetector(
+                                          //   onTap: () {
+                                          //     setState(() {
+                                          //       // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
+                                          //       items[index]['selectedWord'] =
+                                          //           !(items[index]['selectedWord'] ??
+                                          //               false);
+                                          //       // print("Dd");
+                                          //     });
+                                          //   },
+                                          //   child: Padding(
+                                          //     padding: const EdgeInsets.only(
+                                          //         left: 11, top: 8, bottom: 8),
+                                          //     child: Image.asset(
+                                          //       items[index]['selectedWord'] ?? false
+                                          //           ? "assets/bookmark_selected.png"
+                                          //           : "assets/bookmark.png",
+                                          //       width: 13,
+                                          //       height: 18.2,
+                                          //     ),
+                                          //   ),
+                                          // )
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                  if (index !=
+                                      items.length -
+                                          1) // 마지막 항목에는 Divider를 추가하지 않음
+                                    const Divider(
+                                      color: Color(0xFFEBEBEB), // 디바이더 색상
+                                      height: 1, // 높이 설정
+                                      thickness: 1, // 두께 설정
+                                    ),
+                                ],
+                              );
+                            },
+                          ),
+                        );
+                      },
+                    );
+                  })
           ],
         ),
         bottomNavigationBar: const CustomBottomBar(currentIndex: 1),

--- a/economic_fe/lib/view/screens/dictionary_page.dart
+++ b/economic_fe/lib/view/screens/dictionary_page.dart
@@ -1,3 +1,4 @@
+import 'package:economic_fe/data/models/dictionary_model.dart';
 import 'package:economic_fe/view/theme/palette.dart';
 import 'package:economic_fe/view/widgets/custom_app_bar.dart';
 import 'package:economic_fe/view/widgets/custom_bottom_bar.dart';
@@ -146,6 +147,9 @@ class _DictionaryPageState extends State<DictionaryPage> {
                           onTap: () {
                             setState(() {
                               _selectedIndex = index; // 클릭된 항목의 인덱스를 업데이트
+                              controller.selectedConsonant.value =
+                                  consonants[index];
+                              print(controller.selectedConsonant.value);
                             });
                           },
                           child: Container(
@@ -188,84 +192,200 @@ class _DictionaryPageState extends State<DictionaryPage> {
               ),
             ),
             // 단어와 설명을 보여주는 리스트
-            Expanded(
-              child: ListView.builder(
-                itemCount: items.length,
-                itemBuilder: (context, index) {
-                  return Column(
-                    children: [
-                      Container(
-                        margin: const EdgeInsets.symmetric(vertical: 8),
-                        padding: const EdgeInsets.all(16),
-                        decoration: const BoxDecoration(
-                          color: Colors.white,
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            // Expanded(
+            //   child: ListView.builder(
+            //     itemCount: items.length,
+            //     itemBuilder: (context, index) {
+            //       return Column(
+            //         children: [
+            //           Container(
+            //             margin: const EdgeInsets.symmetric(vertical: 8),
+            //             padding: const EdgeInsets.all(16),
+            //             decoration: const BoxDecoration(
+            //               color: Colors.white,
+            //             ),
+            //             child: Row(
+            //               mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            //               children: [
+            //                 SizedBox(
+            //                   child: Column(
+            //                     crossAxisAlignment: CrossAxisAlignment.start,
+            //                     children: [
+            //                       Text(
+            //                         items[index]['word']!, // 단어 표시
+            //                         style: const TextStyle(
+            //                             fontSize: 16,
+            //                             fontWeight: FontWeight.w500,
+            //                             color: Color.fromARGB(255, 0, 0, 0),
+            //                             height: 1.4,
+            //                             letterSpacing: -0.4),
+            //                       ),
+            //                       const SizedBox(height: 8), // 단어와 설명 간 간격
+            //                       Text(
+            //                         items[index]['description'] ?? "설명이 없습니다",
+            //                         style: const TextStyle(
+            //                           fontSize: 14,
+            //                           color: Color(0xFF767676),
+            //                           fontWeight: FontWeight.w400,
+            //                           height: 1.4,
+            //                           letterSpacing: -0.35,
+            //                         ),
+            //                       ),
+            //                     ],
+            //                   ),
+            //                 ),
+            //                 GestureDetector(
+            //                   onTap: () {
+            //                     setState(() {
+            //                       // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
+            //                       items[index]['selectedWord'] =
+            //                           !(items[index]['selectedWord'] ?? false);
+            //                       // print("Dd");
+            //                     });
+            //                   },
+            //                   child: Padding(
+            //                     padding: const EdgeInsets.only(
+            //                         left: 11, top: 8, bottom: 8),
+            //                     child: Image.asset(
+            //                       items[index]['selectedWord'] ?? false
+            //                           ? "assets/bookmark_selected.png"
+            //                           : "assets/bookmark.png",
+            //                       width: 13,
+            //                       height: 18.2,
+            //                     ),
+            //                   ),
+            //                 )
+            //               ],
+            //             ),
+            //           ),
+            //           if (index !=
+            //               items.length - 1) // 마지막 항목에는 Divider를 추가하지 않음
+            //             const Divider(
+            //               color: Color(0xFFEBEBEB), // 디바이더 색상
+            //               height: 1, // 높이 설정
+            //               thickness: 1, // 두께 설정
+            //             ),
+            //         ],
+            //       );
+            //     },
+            //   ),
+            // ),
+            Obx(() {
+              return FutureBuilder<List<DictionaryModel>>(
+                future: controller.getDictionaryList(
+                    1, controller.selectedConsonant.value),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  }
+
+                  // 에러인 경우
+                  if (snapshot.hasError) {
+                    return Center(
+                      child: Text("에러 발생 : ${snapshot.error}"),
+                    );
+                  }
+
+                  // 데이터가 없을 때
+                  if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                    return const Center(
+                      child: Text("용어 사전 데이터가 없습니다."),
+                    );
+                  }
+                  final termList = snapshot.data!;
+
+                  return Expanded(
+                    child: ListView.builder(
+                      itemCount: termList.length,
+                      itemBuilder: (context, index) {
+                        final terms = termList[index];
+                        return Column(
                           children: [
-                            SizedBox(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
+                            Container(
+                              margin: const EdgeInsets.symmetric(vertical: 8),
+                              padding: const EdgeInsets.all(16),
+                              decoration: const BoxDecoration(
+                                color: Colors.white,
+                              ),
+                              child: Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
-                                  Text(
-                                    items[index]['word']!, // 단어 표시
-                                    style: const TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.w500,
-                                        color: Color.fromARGB(255, 0, 0, 0),
-                                        height: 1.4,
-                                        letterSpacing: -0.4),
-                                  ),
-                                  const SizedBox(height: 8), // 단어와 설명 간 간격
-                                  Text(
-                                    items[index]['description'] ?? "설명이 없습니다",
-                                    style: const TextStyle(
-                                      fontSize: 14,
-                                      color: Color(0xFF767676),
-                                      fontWeight: FontWeight.w400,
-                                      height: 1.4,
-                                      letterSpacing: -0.35,
+                                  SizedBox(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          // items[index]['word']!, // 단어 표시
+                                          terms.termName ?? "",
+                                          style: const TextStyle(
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.w500,
+                                              color:
+                                                  Color.fromARGB(255, 0, 0, 0),
+                                              height: 1.4,
+                                              letterSpacing: -0.4),
+                                        ),
+                                        const SizedBox(
+                                            height: 8), // 단어와 설명 간 간격
+                                        Text(
+                                          // items[index]['description'] ??
+                                          //     "설명이 없습니다",
+                                          terms.termDescription ?? "",
+                                          style: const TextStyle(
+                                            fontSize: 14,
+                                            color: Color(0xFF767676),
+                                            fontWeight: FontWeight.w400,
+                                            height: 1.4,
+                                            letterSpacing: -0.35,
+                                          ),
+                                        ),
+                                      ],
                                     ),
                                   ),
+                                  GestureDetector(
+                                    onTap: () {
+                                      setState(() {
+                                        // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
+                                        items[index]['selectedWord'] =
+                                            !(items[index]['selectedWord'] ??
+                                                false);
+                                        // print("Dd");
+                                      });
+                                    },
+                                    child: Padding(
+                                      padding: const EdgeInsets.only(
+                                          left: 11, top: 8, bottom: 8),
+                                      child: Image.asset(
+                                        items[index]['selectedWord'] ?? false
+                                            ? "assets/bookmark_selected.png"
+                                            : "assets/bookmark.png",
+                                        width: 13,
+                                        height: 18.2,
+                                      ),
+                                    ),
+                                  )
                                 ],
                               ),
                             ),
-                            GestureDetector(
-                              onTap: () {
-                                setState(() {
-                                  // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
-                                  items[index]['selectedWord'] =
-                                      !(items[index]['selectedWord'] ?? false);
-                                  print("Dd");
-                                });
-                              },
-                              child: Padding(
-                                padding: const EdgeInsets.only(
-                                    left: 11, top: 8, bottom: 8),
-                                child: Image.asset(
-                                  items[index]['selectedWord'] ?? false
-                                      ? "assets/bookmark_selected.png"
-                                      : "assets/bookmark.png",
-                                  width: 13,
-                                  height: 18.2,
-                                ),
+                            if (index !=
+                                items.length - 1) // 마지막 항목에는 Divider를 추가하지 않음
+                              const Divider(
+                                color: Color(0xFFEBEBEB), // 디바이더 색상
+                                height: 1, // 높이 설정
+                                thickness: 1, // 두께 설정
                               ),
-                            )
                           ],
-                        ),
-                      ),
-                      if (index !=
-                          items.length - 1) // 마지막 항목에는 Divider를 추가하지 않음
-                        const Divider(
-                          color: Color(0xFFEBEBEB), // 디바이더 색상
-                          height: 1, // 높이 설정
-                          thickness: 1, // 두께 설정
-                        ),
-                    ],
+                        );
+                      },
+                    ),
                   );
                 },
-              ),
-            ),
+              );
+            })
           ],
         ),
         bottomNavigationBar: const CustomBottomBar(currentIndex: 1),

--- a/economic_fe/lib/view/screens/dictionary_page.dart
+++ b/economic_fe/lib/view/screens/dictionary_page.dart
@@ -79,6 +79,7 @@ class _DictionaryPageState extends State<DictionaryPage> {
   void initState() {
     super.initState();
     controller = Get.put(DictionaryController()..getStats());
+    controller.getDictionaryList(0, 'ㄱ');
   }
 
   @override
@@ -229,28 +230,24 @@ class _DictionaryPageState extends State<DictionaryPage> {
                                 ],
                               ),
                             ),
-                            Padding(
-                              padding: const EdgeInsets.only(left: 10),
-                              child: GestureDetector(
-                                onTap: () {
-                                  setState(() {
-                                    // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
-                                    items[index]['selectedWord'] =
-                                        !(items[index]['selectedWord'] ??
-                                            false);
-                                    print("Dd");
-                                  });
-                                },
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 11, vertical: 8),
-                                  child: Image.asset(
-                                    items[index]['selectedWord'] ?? false
-                                        ? "assets/bookmark_selected.png"
-                                        : "assets/bookmark.png",
-                                    width: 13,
-                                    height: 18.2,
-                                  ),
+                            GestureDetector(
+                              onTap: () {
+                                setState(() {
+                                  // 'selectedWord'가 null인 경우에는 false로 초기화하고, 값을 반전시킴
+                                  items[index]['selectedWord'] =
+                                      !(items[index]['selectedWord'] ?? false);
+                                  print("Dd");
+                                });
+                              },
+                              child: Padding(
+                                padding: const EdgeInsets.only(
+                                    left: 11, top: 8, bottom: 8),
+                                child: Image.asset(
+                                  items[index]['selectedWord'] ?? false
+                                      ? "assets/bookmark_selected.png"
+                                      : "assets/bookmark.png",
+                                  width: 13,
+                                  height: 18.2,
                                 ),
                               ),
                             )

--- a/economic_fe/lib/view/screens/dictionary_page.dart
+++ b/economic_fe/lib/view/screens/dictionary_page.dart
@@ -80,7 +80,7 @@ class _DictionaryPageState extends State<DictionaryPage> {
   void initState() {
     super.initState();
     controller = Get.put(DictionaryController()..getStats());
-    controller.getDictionaryList(0, 'ㄱ');
+    controller.getDictionaryList(0, 'ㄱ', true);
   }
 
   @override
@@ -103,6 +103,11 @@ class _DictionaryPageState extends State<DictionaryPage> {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               height: 60,
               child: TextFormField(
+                onChanged: (value) {
+                  // 텍스트가 변경될 때마다 controller.keyword를 업데이트
+                  controller.keyword.value = value;
+                  print(controller.keyword.value);
+                },
                 controller: _controller,
                 focusNode: _focusNode,
                 decoration: InputDecoration(
@@ -132,6 +137,15 @@ class _DictionaryPageState extends State<DictionaryPage> {
                   ),
                 ),
               ),
+            ),
+            TextButton(
+              onPressed: () {
+                // controller.
+                print(controller.keyword.value);
+                controller.typeValue.value = false;
+                controller.getKewordResult(0, controller.keyword.value);
+              },
+              child: const Text("검색"),
             ),
             // 자음 리스트 (가로 스크롤)
             Container(
@@ -274,7 +288,11 @@ class _DictionaryPageState extends State<DictionaryPage> {
             Obx(() {
               return FutureBuilder<List<DictionaryModel>>(
                 future: controller.getDictionaryList(
-                    1, controller.selectedConsonant.value),
+                    1,
+                    controller.typeValue.value
+                        ? controller.selectedConsonant.value
+                        : controller.keyword.value,
+                    controller.typeValue.value),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const Center(

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -66,24 +66,15 @@ class ArticleListController extends GetxController {
 
       if (category != null) {
         response = await RemoteDataSource.getNewsList(page, sort, category);
-        print("n   $response");
+        print("category != null $response");
       } else if (category == null || selectedCate == "전체") {
         response = await RemoteDataSource.getNewsList(page, sort, null);
         print("n : $response");
       }
 
-      // print(response);
       final data = response as Map<String, dynamic>;
       final newsList = data['results']['newsList'] as List;
-      // print(newsList);
-      // print("Ddd");
-      // print(newsList.map((news) => ArticleModel.fromJson(news)).toList());
       return newsList.map((news) => ArticleModel.fromJson(news)).toList();
-      // for (final news in newsList) {
-      //   // final title = news['title'];
-      //   // print("뉴스 제목 : $title");
-      //   ArticleModel.fromJson(news);
-      // }
     } catch (e) {
       debugPrint('Error: $e');
       return [];

--- a/economic_fe/lib/view_model/dictionary_controller.dart
+++ b/economic_fe/lib/view_model/dictionary_controller.dart
@@ -32,4 +32,18 @@ class DictionaryController extends GetxController {
       return [];
     }
   }
+
+  //특정 용어 상세 보기
+  Future<void> getTermDetail(int id) async {
+    try {
+      print("start");
+
+      dynamic response;
+
+      response = await RemoteDataSource.getDetailTerms(id);
+      print("respose : $response");
+    } catch (e) {
+      debugPrint('Error: $e');
+    }
+  }
 }

--- a/economic_fe/lib/view_model/dictionary_controller.dart
+++ b/economic_fe/lib/view_model/dictionary_controller.dart
@@ -1,3 +1,5 @@
+import 'package:economic_fe/data/models/dictionary_model.dart';
+import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:go_router/go_router.dart'; // GoRouter import
@@ -5,8 +7,29 @@ import 'package:go_router/go_router.dart'; // GoRouter import
 class DictionaryController extends GetxController {
   late BuildContext context;
 
+  var selectedConsonant = "ㄱ".obs;
+
   void getStats() {
     // 통계 데이터 로드 또는 초기화 작업
     print("Stats initialized!");
+  }
+
+  //용어 사전 데이터 불러오기
+  Future<List<DictionaryModel>> getDictionaryList(
+      int page, String consonant) async {
+    try {
+      print("start");
+      dynamic response;
+
+      response = await RemoteDataSource.getDictionary(page, consonant);
+      print("response :: $response");
+
+      final data = response as Map<String, dynamic>;
+      final termList = data['results']['termList'] as List;
+      return termList.map((term) => DictionaryModel.fromJson(term)).toList();
+    } catch (e) {
+      debugPrint('Error: $e');
+      return [];
+    }
   }
 }

--- a/economic_fe/lib/view_model/dictionary_controller.dart
+++ b/economic_fe/lib/view_model/dictionary_controller.dart
@@ -34,6 +34,7 @@ class DictionaryController extends GetxController {
         final termList = data['results']['termList'] as List;
         return termList.map((term) => DictionaryModel.fromJson(term)).toList();
       } else {
+        print("검색");
         response = await RemoteDataSource.getKewordResult(page, text);
         print("response : $response");
 

--- a/economic_fe/lib/view_model/dictionary_controller.dart
+++ b/economic_fe/lib/view_model/dictionary_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:economic_fe/data/models/dictionary_model.dart';
 import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:flutter/material.dart';
@@ -8,6 +10,8 @@ class DictionaryController extends GetxController {
   late BuildContext context;
 
   var selectedConsonant = "ㄱ".obs;
+  var keyword = "".obs;
+  var typeValue = true.obs; //false : 검색
 
   void getStats() {
     // 통계 데이터 로드 또는 초기화 작업
@@ -16,24 +20,49 @@ class DictionaryController extends GetxController {
 
   //용어 사전 데이터 불러오기
   Future<List<DictionaryModel>> getDictionaryList(
-      int page, String consonant) async {
+      int page, String text, bool type) async {
+    // type = true : 그 외 init, false : 검색
     try {
       print("start");
       dynamic response;
 
-      response = await RemoteDataSource.getDictionary(page, consonant);
-      print("response :: $response");
+      if (type) {
+        response = await RemoteDataSource.getDictionary(page, text);
+        print("response :: $response");
 
-      final data = response as Map<String, dynamic>;
-      final termList = data['results']['termList'] as List;
-      return termList.map((term) => DictionaryModel.fromJson(term)).toList();
+        final data = response as Map<String, dynamic>;
+        final termList = data['results']['termList'] as List;
+        return termList.map((term) => DictionaryModel.fromJson(term)).toList();
+      } else {
+        response = await RemoteDataSource.getKewordResult(page, text);
+        print("response : $response");
+
+        final data = response as Map<String, dynamic>;
+        final termList = data['results']['termList'] as List;
+        return termList.map((term) => DictionaryModel.fromJson(term)).toList();
+      }
     } catch (e) {
       debugPrint('Error: $e');
       return [];
     }
   }
 
-  //특정 용어 상세 보기
+  // 키워드로 검색하기
+  Future<void> getKewordResult(int page, String keyword) async {
+    try {
+      print("start");
+
+      dynamic response;
+
+      response = await RemoteDataSource.getKewordResult(page, keyword);
+      print("response : $response");
+      // final data = response as Map<String, dynamic>;
+    } catch (e) {
+      debugPrint("Error : $e");
+    }
+  }
+
+  // 특정 용어 상세 보기
   Future<void> getTermDetail(int id) async {
     try {
       print("start");


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] 뉴스 기사 클릭 후 넘어가는 detail page 구현
- [x] 용어 사전 받아올 DictionaryModel 생성
- [x] 자음별로 용어 검색 api 연동
- [x] 키워드로 용어 검색 api 연동
- [x] 용어 상세 조회 api 연동
- [x] 용어 상세 조회 팝업 구현 
- [ ] 백엔드 스크랩 추가되면 이후에 UI 수정 예정

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<table>
<tr><td>자음 선택 ('ㅍ')</td><td>자음 선택 ('ㅁ')</td><td>용어 상세보기</td></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/cbf7d25e-0835-42a3-8d17-0e42c2c6c345" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/4fb83f45-3005-4549-92a5-9edaa41af4bc" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/77949660-96d0-4556-ab3b-b85badba6d35" width="150"></td>
</tr>
</table>

<table>
<tr><td>검색</td><td>검색 후 상세보기</td></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/a57bd374-f2a3-42b0-8a61-08360ac63c83" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/30ea0d58-2f9c-482f-a9e7-02b263198120" width="150"></td>
</tr>
</table>
