### PR TITLE
FEAT: 마이페이지 UI 구현

### DIFF
--- a/economic_fe/ios/Podfile.lock
+++ b/economic_fe/ios/Podfile.lock
@@ -1,0 +1,48 @@
+PODS:
+  - Flutter (1.0.0)
+  - image_picker_ios (0.0.1):
+    - Flutter
+  - kakao_flutter_sdk_common (1.9.6):
+    - Flutter
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
+  kakao_flutter_sdk_common:
+    :path: ".symlinks/plugins/kakao_flutter_sdk_common/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  kakao_flutter_sdk_common: 4f10f98226da5d0f7cbdeeaed5cc21f144515209
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
+
+PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+
+COCOAPODS: 1.16.2

--- a/economic_fe/ios/Runner.xcodeproj/project.pbxproj
+++ b/economic_fe/ios/Runner.xcodeproj/project.pbxproj
@@ -9,7 +9,9 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
+		3389E6316B7F097787384CE2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF4B51DABFC3553B2CCA075D /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		61582D882ADDE1B386776A4B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BF3DBF41A94FB908BA14615 /* Pods_RunnerTests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -42,12 +44,15 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1BFBFD3BED6A27D0D1257DE8 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		496283AF4D63E9DBECDEA818 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		969239FC0663D12BE9CE7320 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,13 +60,27 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9BF3DBF41A94FB908BA14615 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C50E983BD46532D65A796B0D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		CDFC5B69FC791B7D3ED1900B /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		D2B6FA9D533A31C05D7D1EBA /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FF4B51DABFC3553B2CCA075D /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		7338DB0ABFB3E95066D0033C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61582D882ADDE1B386776A4B /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3389E6316B7F097787384CE2 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +93,15 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		6BBB39ACE5671DFFA1029F16 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FF4B51DABFC3553B2CCA075D /* Pods_Runner.framework */,
+				9BF3DBF41A94FB908BA14615 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +122,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				CC6D70424919A187F5C3A77B /* Pods */,
+				6BBB39ACE5671DFFA1029F16 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +151,20 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		CC6D70424919A187F5C3A77B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1BFBFD3BED6A27D0D1257DE8 /* Pods-Runner.debug.xcconfig */,
+				C50E983BD46532D65A796B0D /* Pods-Runner.release.xcconfig */,
+				CDFC5B69FC791B7D3ED1900B /* Pods-Runner.profile.xcconfig */,
+				D2B6FA9D533A31C05D7D1EBA /* Pods-RunnerTests.debug.xcconfig */,
+				969239FC0663D12BE9CE7320 /* Pods-RunnerTests.release.xcconfig */,
+				496283AF4D63E9DBECDEA818 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				14C089F3EEE878B8276391C8 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				7338DB0ABFB3E95066D0033C /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				885982B6ADA03A70F5F7CD69 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				2B189CB409D4C284480E6742 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,6 +270,45 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		14C089F3EEE878B8276391C8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2B189CB409D4C284480E6742 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -237,6 +324,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		885982B6ADA03A70F5F7CD69 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -378,6 +487,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D2B6FA9D533A31C05D7D1EBA /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +505,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 969239FC0663D12BE9CE7320 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +521,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 496283AF4D63E9DBECDEA818 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/economic_fe/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/economic_fe/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/economic_fe/lib/data/services/image_picker_service.dart
+++ b/economic_fe/lib/data/services/image_picker_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
 class ImagePickerService {
@@ -8,8 +9,77 @@ class ImagePickerService {
     return await _picker.pickImage(source: ImageSource.gallery);
   }
 
-  // 카메라로 사진 찍기
+  // 카메라로 이미지 캡처
   Future<XFile?> pickImageFromCamera() async {
     return await _picker.pickImage(source: ImageSource.camera);
+  }
+
+  // 프로필 사진 선택 다이얼로그
+  Future<XFile?> showImagePickerDialog(BuildContext context) async {
+    return await showDialog<XFile?>(
+      context: context,
+      builder: (context) {
+        return Dialog(
+          backgroundColor: Colors.white,
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 25, horizontal: 27),
+            child: Column(
+              mainAxisSize: MainAxisSize.min, // 다이얼로그 크기를 내용에 맞게 조정
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '프로필 사진',
+                  style: TextStyle(
+                    color: Color(0xFF111111),
+                    fontSize: 24,
+                    fontWeight: FontWeight.w600,
+                    height: 1.30,
+                    letterSpacing: -0.60,
+                  ),
+                ),
+                const SizedBox(
+                  height: 25.5,
+                ),
+                // 사진첩 버튼
+                GestureDetector(
+                  onTap: () async {
+                    Navigator.pop(context, await pickImageFromGallery());
+                  },
+                  child: const Text(
+                    '사진첩',
+                    style: TextStyle(
+                      color: Color(0xFF111111),
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 1.30,
+                      letterSpacing: -0.50,
+                    ),
+                  ),
+                ),
+                const SizedBox(
+                  height: 28,
+                ),
+                // 카메라 버튼
+                GestureDetector(
+                  onTap: () async {
+                    Navigator.pop(context, await pickImageFromCamera());
+                  },
+                  child: const Text(
+                    '카메라',
+                    style: TextStyle(
+                      color: Color(0xFF111111),
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 1.30,
+                      letterSpacing: -0.50,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 }

--- a/economic_fe/lib/data/services/user_router.dart
+++ b/economic_fe/lib/data/services/user_router.dart
@@ -16,6 +16,7 @@ import 'package:economic_fe/view/screens/home_page.dart';
 import 'package:economic_fe/view/screens/learning_set/learning_list_page.dart';
 import 'package:economic_fe/view/screens/leveltest_result_page.dart';
 import 'package:economic_fe/view/screens/login/login_exist_page.dart';
+import 'package:economic_fe/view/screens/mypage/mypage_home_page.dart';
 
 import 'package:economic_fe/view/screens/onboarding/onboarding_card_page.dart';
 
@@ -177,6 +178,11 @@ class UserRouter {
       GetPage(
         name: '/finish',
         page: () => const FinishPage(),
+      ),
+      // 마이페이지
+      GetPage(
+        name: '/mypage',
+        page: () => const MypageHomePage(),
       ),
     ];
   }

--- a/economic_fe/lib/data/services/user_router.dart
+++ b/economic_fe/lib/data/services/user_router.dart
@@ -19,6 +19,7 @@ import 'package:economic_fe/view/screens/login/login_exist_page.dart';
 import 'package:economic_fe/view/screens/mypage/bookmarked_articles_page.dart';
 import 'package:economic_fe/view/screens/mypage/community_activity_page.dart';
 import 'package:economic_fe/view/screens/mypage/mypage_home_page.dart';
+import 'package:economic_fe/view/screens/mypage/setting_page.dart';
 
 import 'package:economic_fe/view/screens/onboarding/onboarding_card_page.dart';
 
@@ -186,6 +187,11 @@ class UserRouter {
         name: '/mypage',
         page: () => const MypageHomePage(),
         children: [
+          // 설정 및 약관
+          GetPage(
+            name: '/setting',
+            page: () => const SettingPage(),
+          ),
           // 스크랩 한 기사
           GetPage(
             name: '/article',

--- a/economic_fe/lib/data/services/user_router.dart
+++ b/economic_fe/lib/data/services/user_router.dart
@@ -17,6 +17,7 @@ import 'package:economic_fe/view/screens/learning_set/learning_list_page.dart';
 import 'package:economic_fe/view/screens/leveltest_result_page.dart';
 import 'package:economic_fe/view/screens/login/login_exist_page.dart';
 import 'package:economic_fe/view/screens/mypage/bookmarked_articles_page.dart';
+import 'package:economic_fe/view/screens/mypage/community_activity_page.dart';
 import 'package:economic_fe/view/screens/mypage/mypage_home_page.dart';
 
 import 'package:economic_fe/view/screens/onboarding/onboarding_card_page.dart';
@@ -189,6 +190,11 @@ class UserRouter {
           GetPage(
             name: '/article',
             page: () => const BookmarkedArticlesPage(),
+          ),
+          // 커뮤니티 활동
+          GetPage(
+            name: '/community',
+            page: () => const CommunityActivityPage(),
           ),
         ],
       ),

--- a/economic_fe/lib/data/services/user_router.dart
+++ b/economic_fe/lib/data/services/user_router.dart
@@ -17,6 +17,7 @@ import 'package:economic_fe/view/screens/learning_set/learning_list_page.dart';
 import 'package:economic_fe/view/screens/leveltest_result_page.dart';
 import 'package:economic_fe/view/screens/login/login_exist_page.dart';
 import 'package:economic_fe/view/screens/mypage/bookmarked_articles_page.dart';
+import 'package:economic_fe/view/screens/mypage/bookmarked_post_page.dart';
 import 'package:economic_fe/view/screens/mypage/community_activity_page.dart';
 import 'package:economic_fe/view/screens/mypage/mypage_home_page.dart';
 import 'package:economic_fe/view/screens/mypage/setting_page.dart';
@@ -201,6 +202,13 @@ class UserRouter {
           GetPage(
             name: '/community',
             page: () => const CommunityActivityPage(),
+            children: [
+              // 스크랩 한 글/좋아요 한 글/좋아요 한 댓글
+              GetPage(
+                name: '/post',
+                page: () => const BookmarkedPostPage(),
+              ),
+            ],
           ),
         ],
       ),

--- a/economic_fe/lib/data/services/user_router.dart
+++ b/economic_fe/lib/data/services/user_router.dart
@@ -16,6 +16,7 @@ import 'package:economic_fe/view/screens/home_page.dart';
 import 'package:economic_fe/view/screens/learning_set/learning_list_page.dart';
 import 'package:economic_fe/view/screens/leveltest_result_page.dart';
 import 'package:economic_fe/view/screens/login/login_exist_page.dart';
+import 'package:economic_fe/view/screens/mypage/bookmarked_articles_page.dart';
 import 'package:economic_fe/view/screens/mypage/mypage_home_page.dart';
 
 import 'package:economic_fe/view/screens/onboarding/onboarding_card_page.dart';
@@ -183,6 +184,13 @@ class UserRouter {
       GetPage(
         name: '/mypage',
         page: () => const MypageHomePage(),
+        children: [
+          // 스크랩 한 기사
+          GetPage(
+            name: '/article',
+            page: () => const BookmarkedArticlesPage(),
+          ),
+        ],
       ),
     ];
   }

--- a/economic_fe/lib/data/services/user_router.dart
+++ b/economic_fe/lib/data/services/user_router.dart
@@ -19,6 +19,7 @@ import 'package:economic_fe/view/screens/login/login_exist_page.dart';
 import 'package:economic_fe/view/screens/mypage/bookmarked_articles_page.dart';
 import 'package:economic_fe/view/screens/mypage/bookmarked_post_page.dart';
 import 'package:economic_fe/view/screens/mypage/community_activity_page.dart';
+import 'package:economic_fe/view/screens/mypage/my_learning_page.dart';
 import 'package:economic_fe/view/screens/mypage/mypage_home_page.dart';
 import 'package:economic_fe/view/screens/mypage/setting_page.dart';
 
@@ -209,6 +210,11 @@ class UserRouter {
                 page: () => const BookmarkedPostPage(),
               ),
             ],
+          ),
+          // 나의 학습
+          GetPage(
+            name: '/learning',
+            page: () => const MyLearningPage(),
           ),
         ],
       ),

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/article',
+      initialRoute: '/mypage',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/view/screens/mypage/bookmarked_articles_page.dart
+++ b/economic_fe/lib/view/screens/mypage/bookmarked_articles_page.dart
@@ -1,0 +1,122 @@
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:economic_fe/view/widgets/custom_app_bar.dart';
+import 'package:economic_fe/view_model/mypage/bookmarked_articles_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class BookmarkedArticlesPage extends StatefulWidget {
+  const BookmarkedArticlesPage({super.key});
+
+  @override
+  State<BookmarkedArticlesPage> createState() => _BookmarkedArticlesPageState();
+}
+
+class _BookmarkedArticlesPageState extends State<BookmarkedArticlesPage> {
+  final BookmarkedArticlesController controller =
+      Get.put(BookmarkedArticlesController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Palette.background,
+      appBar: CustomAppBar(
+        title: '스크랩 한 기사',
+        icon: Icons.close,
+        onPress: () => Get.back(),
+      ),
+      body: ListView.builder(
+        itemCount: controller.articles.length,
+        itemBuilder: (context, index) {
+          final news = controller.articles[index];
+          return Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Container(
+              padding: const EdgeInsets.all(16.0),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12.0),
+                border: const Border(
+                  bottom: BorderSide(
+                    color: Color(0xFFD9D9D9),
+                    width: 1,
+                  ),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    news.category,
+                    style: const TextStyle(
+                      color: Color(0xFF2BD6D6),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: -0.3,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 6,
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          // controller.toDetailPage);
+                        },
+                        child: Text(
+                          news.headline ?? "제목 없음",
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                            height: 1.3,
+                            letterSpacing: -0.4,
+                          ),
+                        ),
+                      ),
+                      GestureDetector(
+                        onTap: () {},
+                        child: const Icon(
+                          Icons.bookmark,
+                          color: Palette.buttonColorGreen,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        news.publisher ?? "알 수 없음",
+                        style: const TextStyle(
+                          color: Color(0xFF767676),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 1.5,
+                          letterSpacing: -0.3,
+                        ),
+                      ),
+                      // 기사 업로드 시간
+                      Text(
+                        news.uploadTime,
+                        style: const TextStyle(
+                          color: Color(0xFF767676),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                          letterSpacing: -0.30,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view/screens/mypage/bookmarked_post_page.dart
+++ b/economic_fe/lib/view/screens/mypage/bookmarked_post_page.dart
@@ -1,0 +1,132 @@
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:economic_fe/view/widgets/custom_app_bar.dart';
+import 'package:economic_fe/view_model/mypage/bookmarked_posts_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class BookmarkedPostPage extends StatefulWidget {
+  const BookmarkedPostPage({super.key});
+
+  @override
+  State<BookmarkedPostPage> createState() => _BookmarkedPostPageState();
+}
+
+class _BookmarkedPostPageState extends State<BookmarkedPostPage> {
+  final BookmarkedPostsController controller =
+      Get.put(BookmarkedPostsController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Palette.background,
+      appBar: CustomAppBar(
+        title: controller.argument,
+        icon: Icons.close,
+        onPress: () => Get.back(),
+      ),
+      body: Obx(() {
+        // posts가 비어있는 경우 처리
+        if (controller.posts.isEmpty) {
+          return const Center(
+            child: Text(
+              '데이터가 없습니다.',
+              style: TextStyle(
+                fontSize: 16,
+                color: Color(0xFF767676),
+              ),
+            ),
+          );
+        }
+
+        return ListView.builder(
+          itemCount: controller.posts.length,
+          itemBuilder: (context, index) {
+            final post = controller.posts[index];
+            return Container(
+              padding: const EdgeInsets.all(16.0),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12.0),
+                border: const Border(
+                  bottom: BorderSide(
+                    color: Color(0xFFD9D9D9),
+                    width: 1,
+                  ),
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          post["category"]!,
+                          style: const TextStyle(
+                            color: Color(0xFF767676),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w400,
+                            height: 1.30,
+                            letterSpacing: -0.30,
+                          ),
+                        ),
+                        Text(
+                          post["uploadTime"]!,
+                          style: const TextStyle(
+                            color: Color(0xFF767676),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w400,
+                            height: 1.50,
+                            letterSpacing: -0.30,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(
+                      height: 6,
+                    ),
+                    GestureDetector(
+                      onTap: () {
+                        // 게시글 상세 페이지 이동
+                      },
+                      child: Text(
+                        post["title"]!,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          height: 1.3,
+                          letterSpacing: -0.4,
+                        ),
+                      ),
+                    ),
+                    controller.argument == "좋아요 한 댓글"
+                        ? Column(
+                            children: [
+                              const SizedBox(
+                                height: 6,
+                              ),
+                              Text(
+                                post["postTitle"]!,
+                                style: const TextStyle(
+                                  color: Color(0xFFA2A2A2),
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w400,
+                                  height: 1.30,
+                                  letterSpacing: -0.30,
+                                ),
+                              ),
+                            ],
+                          )
+                        : const SizedBox(),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/economic_fe/lib/view/screens/mypage/community_activity_page.dart
+++ b/economic_fe/lib/view/screens/mypage/community_activity_page.dart
@@ -1,5 +1,7 @@
 import 'package:economic_fe/view/theme/palette.dart';
 import 'package:economic_fe/view/widgets/custom_app_bar.dart';
+import 'package:economic_fe/view/widgets/mypage/category_options.dart';
+import 'package:economic_fe/view/widgets/mypage/category_text.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -44,69 +46,6 @@ class _CommunityActivityPageState extends State<CommunityActivityPage> {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class CategoryOptions extends StatelessWidget {
-  final String text;
-  final Function() onTap;
-
-  const CategoryOptions({
-    super.key,
-    required this.text,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 6, top: 27.5),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            text,
-            style: const TextStyle(
-              color: Color(0xFF111111),
-              fontSize: 16,
-              fontWeight: FontWeight.w400,
-              height: 1.40,
-              letterSpacing: -0.40,
-            ),
-          ),
-          GestureDetector(
-            onTap: onTap,
-            child: const Icon(
-              Icons.arrow_forward_ios,
-              size: 15,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class CategoryText extends StatelessWidget {
-  final String text;
-
-  const CategoryText({
-    super.key,
-    required this.text,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      text,
-      style: const TextStyle(
-        color: Color(0xFF111111),
-        fontSize: 18,
-        fontWeight: FontWeight.w500,
-        height: 1.30,
-        letterSpacing: -0.45,
       ),
     );
   }

--- a/economic_fe/lib/view/screens/mypage/community_activity_page.dart
+++ b/economic_fe/lib/view/screens/mypage/community_activity_page.dart
@@ -1,0 +1,113 @@
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:economic_fe/view/widgets/custom_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class CommunityActivityPage extends StatefulWidget {
+  const CommunityActivityPage({super.key});
+
+  @override
+  State<CommunityActivityPage> createState() => _CommunityActivityPageState();
+}
+
+class _CommunityActivityPageState extends State<CommunityActivityPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Palette.background,
+      appBar: CustomAppBar(
+        title: '커뮤니티 활동',
+        icon: Icons.arrow_back_ios_new,
+        onPress: () => Get.back(),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 13.5),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const CategoryText(text: '스크랩'),
+            CategoryOptions(
+              text: '스크랩 한 글',
+              onTap: () {},
+            ),
+            const SizedBox(
+              height: 31.5,
+            ),
+            const CategoryText(text: '좋아요'),
+            CategoryOptions(
+              text: '좋아요 한 글',
+              onTap: () {},
+            ),
+            CategoryOptions(
+              text: '좋아요 한 댓글',
+              onTap: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CategoryOptions extends StatelessWidget {
+  final String text;
+  final Function() onTap;
+
+  const CategoryOptions({
+    super.key,
+    required this.text,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 6, top: 27.5),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            text,
+            style: const TextStyle(
+              color: Color(0xFF111111),
+              fontSize: 16,
+              fontWeight: FontWeight.w400,
+              height: 1.40,
+              letterSpacing: -0.40,
+            ),
+          ),
+          GestureDetector(
+            onTap: onTap,
+            child: const Icon(
+              Icons.arrow_forward_ios,
+              size: 15,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CategoryText extends StatelessWidget {
+  final String text;
+
+  const CategoryText({
+    super.key,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: Color(0xFF111111),
+        fontSize: 18,
+        fontWeight: FontWeight.w500,
+        height: 1.30,
+        letterSpacing: -0.45,
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view/screens/mypage/community_activity_page.dart
+++ b/economic_fe/lib/view/screens/mypage/community_activity_page.dart
@@ -30,7 +30,12 @@ class _CommunityActivityPageState extends State<CommunityActivityPage> {
             const CategoryText(text: '스크랩'),
             CategoryOptions(
               text: '스크랩 한 글',
-              onTap: () {},
+              onTap: () {
+                Get.toNamed(
+                  '/mypage/community/post',
+                  arguments: '스크랩 한 글',
+                );
+              },
             ),
             const SizedBox(
               height: 31.5,
@@ -38,11 +43,21 @@ class _CommunityActivityPageState extends State<CommunityActivityPage> {
             const CategoryText(text: '좋아요'),
             CategoryOptions(
               text: '좋아요 한 글',
-              onTap: () {},
+              onTap: () {
+                Get.toNamed(
+                  '/mypage/community/post',
+                  arguments: '좋아요 한 글',
+                );
+              },
             ),
             CategoryOptions(
               text: '좋아요 한 댓글',
-              onTap: () {},
+              onTap: () {
+                Get.toNamed(
+                  '/mypage/community/post',
+                  arguments: '좋아요 한 댓글',
+                );
+              },
             ),
           ],
         ),

--- a/economic_fe/lib/view/screens/mypage/my_learning_page.dart
+++ b/economic_fe/lib/view/screens/mypage/my_learning_page.dart
@@ -1,0 +1,239 @@
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:economic_fe/view/widgets/custom_app_bar.dart';
+import 'package:economic_fe/view_model/mypage/my_learning_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class MyLearningPage extends StatefulWidget {
+  const MyLearningPage({super.key});
+
+  @override
+  State<MyLearningPage> createState() => _MyLearningPageState();
+}
+
+class _MyLearningPageState extends State<MyLearningPage> {
+  final MyLearningController controller = Get.put(MyLearningController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Palette.background,
+      appBar: CustomAppBar(
+        title: '나의 학습',
+        icon: Icons.arrow_back_ios_new,
+        onPress: () => Get.back(),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.only(top: 12),
+        child: Column(
+          children: [
+            Container(
+              height: 1,
+              color: Colors.black,
+            ),
+            // 탭바
+            Container(
+              color: Colors.white,
+              child: TabBar(
+                controller: controller.tabController,
+                labelColor: Colors.black,
+                labelStyle: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+                unselectedLabelColor: const Color(0xff767676),
+                indicatorColor: Colors.black,
+                indicatorWeight: 3.0,
+                tabs: const [
+                  Tab(text: '스크랩 한 퀴즈'),
+                  Tab(text: '스크랩 한 학습'),
+                  Tab(text: '틀린 문제'),
+                ],
+              ),
+            ),
+            // 레벨 선택
+            Padding(
+              padding: const EdgeInsets.only(top: 22, left: 15),
+              child: Row(
+                children: [
+                  Obx(
+                    () => LevelContainer(
+                      level: '초급',
+                      isSelected: controller.selectedLevel.value == '초급',
+                      onTap: () => controller.updateSelectedLevel('초급'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Obx(
+                    () => LevelContainer(
+                      level: '중급',
+                      isSelected: controller.selectedLevel.value == '중급',
+                      onTap: () => controller.updateSelectedLevel('중급'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Obx(
+                    () => LevelContainer(
+                      level: '고급',
+                      isSelected: controller.selectedLevel.value == '고급',
+                      onTap: () => controller.updateSelectedLevel('고급'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 18),
+            // 버튼
+            Padding(
+              padding: const EdgeInsets.only(left: 16),
+              child: GestureDetector(
+                onTap: () {
+                  // 버튼 클릭 시 동작
+                },
+                child: Obx(
+                  () => Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            controller.buttonText.value,
+                            style: const TextStyle(
+                              color: Color(0xFF067BD5),
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                              height: 1.40,
+                              letterSpacing: -0.35,
+                            ),
+                          ),
+                          const SizedBox(width: 3),
+                          const Icon(
+                            Icons.arrow_circle_right,
+                            color: Color(0xff067bd5),
+                            size: 15,
+                          ),
+                        ],
+                      ),
+                      Container(
+                        width: controller.buttonText.value == '틀린 모든 문제 다시 풀기'
+                            ? 158
+                            : 185,
+                        height: 1,
+                        color: const Color(0xff067bd5),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 15),
+            // 탭별 데이터 리스트
+            Expanded(
+              child: Obx(
+                () => ListView.builder(
+                  itemCount: controller.currentData.length,
+                  itemBuilder: (context, index) {
+                    final item = controller.currentData[index];
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 8),
+                      child: Container(
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(
+                            color: const Color(0xFFD9D9D9),
+                            width: 1,
+                          ),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  item['category']!,
+                                  style: const TextStyle(
+                                    color: Color(0xFF767676),
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.w400,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  item['title']!,
+                                  style: const TextStyle(
+                                    color: Color(0xFF404040),
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            GestureDetector(
+                              onTap: () {},
+                              child: const Icon(
+                                Icons.bookmark,
+                                color: Palette.buttonColorGreen,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class LevelContainer extends StatelessWidget {
+  final String level;
+  final bool isSelected;
+  final Function() onTap;
+
+  const LevelContainer({
+    super.key,
+    required this.level,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 6),
+        decoration: ShapeDecoration(
+          color: isSelected ? const Color(0xFF1DB691) : Colors.white,
+          shape: RoundedRectangleBorder(
+            side: BorderSide(
+                width: 1,
+                color: isSelected
+                    ? Palette.buttonColorGreen
+                    : const Color(0xFFD9D9D9)),
+            borderRadius: BorderRadius.circular(10),
+          ),
+        ),
+        child: Text(
+          level,
+          style: TextStyle(
+            color: isSelected ? Colors.white : const Color(0xffa2a2a2),
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            height: 1.50,
+            letterSpacing: -0.35,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
+++ b/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
@@ -343,7 +343,9 @@ class _MypageHomePageState extends State<MypageHomePage> {
             MyContentsContainer(
               title: '나의 학습',
               subTitle: '스크랩 한 퀴즈, 학습, 틀린 문제를 확인해요',
-              onTap: () {},
+              onTap: () {
+                Get.toNamed('/mypage/learning');
+              },
             ),
             const SizedBox(
               height: 12,

--- a/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
+++ b/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
@@ -349,7 +349,9 @@ class _MypageHomePageState extends State<MypageHomePage> {
             MyContentsContainer(
               title: '커뮤니티 활동',
               subTitle: '스크랩 및 좋아요 한 커뮤니티 내용을 확인해요',
-              onTap: () {},
+              onTap: () {
+                Get.toNamed('/mypage/community');
+              },
             ),
             const SizedBox(
               height: 12,

--- a/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
+++ b/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
@@ -1,0 +1,517 @@
+import 'dart:io';
+
+import 'package:economic_fe/utils/screen_utils.dart';
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:economic_fe/view/widgets/custom_bottom_bar.dart';
+import 'package:economic_fe/view/widgets/profile_setting/profile_button_unselected.dart';
+import 'package:economic_fe/view_model/mypage/mypage_home_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class MypageHomePage extends StatefulWidget {
+  const MypageHomePage({super.key});
+
+  @override
+  State<MypageHomePage> createState() => _MypageHomePageState();
+}
+
+class _MypageHomePageState extends State<MypageHomePage> {
+  final MypageHomeController controller = Get.put(MypageHomeController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Palette.background,
+      appBar: AppBar(
+        backgroundColor: Palette.background,
+        forceMaterialTransparency: true,
+        automaticallyImplyLeading: false,
+        title: Row(
+          children: [
+            Image.asset(
+              'assets/icon.png',
+              width: 25.88,
+              height: 31.74,
+            ),
+            const SizedBox(
+              width: 4,
+            ),
+            const Text(
+              'Ripple',
+              style: TextStyle(
+                color: Color(0xFF111111),
+                fontSize: 22.40,
+                fontFamily: 'Palanquin',
+                fontWeight: FontWeight.w400,
+                letterSpacing: -0.45,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          GestureDetector(
+            onTap: () {}, // 알림 화면으로
+            child: const Icon(
+              Icons.notifications_none,
+              size: 24,
+              color: Color(0xff1c1b1f),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 20, left: 8),
+            child: GestureDetector(
+              onTap: () {}, // 설정 화면으로
+              child: const Icon(
+                Icons.settings_outlined,
+                size: 24,
+                color: Color(0xff1c1b1f),
+              ),
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: const CustomBottomBar(currentIndex: 4),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: ListView(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 10),
+              child: Row(
+                children: [
+                  // 사용자 프로필 사진
+                  SizedBox(
+                    height: 81,
+                    child: Stack(
+                      children: [
+                        Container(
+                          width: 81,
+                          height: 81,
+                          decoration: ShapeDecoration(
+                            color: const Color(0xFFF3F3F3),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(43),
+                            ),
+                          ),
+                          child: Obx(() {
+                            return controller.selectedProfileImage.value != null
+                                ? ClipOval(
+                                    child: Image.file(
+                                      File(controller
+                                          .selectedProfileImage.value!),
+                                      fit: BoxFit.cover,
+                                      width: 81,
+                                      height: 81,
+                                    ),
+                                  )
+                                : const Icon(
+                                    Icons.person,
+                                    size: 35,
+                                  );
+                          }),
+                        ),
+                        Positioned(
+                          bottom: 0,
+                          right: 0,
+                          // 카메라 버튼
+                          child: GestureDetector(
+                            onTap: () {
+                              controller.selectProfileImage(context);
+                            },
+                            child: Container(
+                              width: 26,
+                              height: 26,
+                              decoration: ShapeDecoration(
+                                color: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(26),
+                                ),
+                                shadows: const [
+                                  BoxShadow(
+                                    color: Color(0x3F000000),
+                                    blurRadius: 4,
+                                    offset: Offset(0, 0),
+                                    spreadRadius: 0,
+                                  )
+                                ],
+                              ),
+                              child: const Icon(
+                                Icons.edit_outlined,
+                                size: 15,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(
+                    width: 16,
+                  ),
+                  const Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // 사용자 이름
+                      Text(
+                        '리플',
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w600,
+                          height: 1.40,
+                          letterSpacing: -0.50,
+                        ),
+                      ),
+                      // 생년월일
+                      Text(
+                        '1996. 11. 18',
+                        style: TextStyle(
+                          color: Color(0xFF767676),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                          letterSpacing: -0.30,
+                        ),
+                      ),
+                      SizedBox(
+                        height: 6,
+                      ),
+                      // 한 줄 소개
+                      Text(
+                        '만나서 반가워요.',
+                        style: TextStyle(
+                          color: Color(0xFF404040),
+                          fontSize: 14,
+                          fontWeight: FontWeight.w400,
+                          height: 1.30,
+                          letterSpacing: -0.35,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.only(top: 17),
+              child: Row(
+                children: [
+                  // 직무
+                  JobContainer(text: '개발자(프론트엔드/백엔드)'),
+                  SizedBox(
+                    width: 8,
+                  ),
+                  // 업종
+                  JobContainer(text: '스타트업/벤처'),
+                ],
+              ),
+            ),
+            const SizedBox(
+              height: 24,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Column(
+                    children: [
+                      Text(
+                        '연속 학습일',
+                        style: TextStyle(
+                          color: Color(0xFF4A4A4A),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 0.80,
+                        ),
+                      ),
+                      SizedBox(
+                        height: 11,
+                      ),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          // 연속 학습일 수
+                          Text(
+                            '3',
+                            style: TextStyle(
+                              color: Color(0xFF2AD6D6),
+                              fontSize: 32,
+                              fontWeight: FontWeight.w600,
+                              height: 0.80,
+                            ),
+                          ),
+                          Text(
+                            '일째',
+                            style: TextStyle(
+                              color: Color(0xFF4A4A4A),
+                              fontSize: 12,
+                              fontWeight: FontWeight.w400,
+                              height: 0.80,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  Container(
+                    width: 1,
+                    height: 76,
+                    color: const Color(0xffa2a2a2),
+                  ),
+                  const Column(
+                    children: [
+                      Text(
+                        '나의 레벨',
+                        style: TextStyle(
+                          color: Color(0xFF4A4A4A),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 0.80,
+                        ),
+                      ),
+                      SizedBox(
+                        height: 9,
+                      ),
+                      // 나의 레벨
+                      Text(
+                        '중급',
+                        style: TextStyle(
+                          color: Color(0xFF2AD6D6),
+                          fontSize: 24,
+                          fontWeight: FontWeight.w700,
+                          height: 1.30,
+                          letterSpacing: -0.60,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Container(
+                    width: 1,
+                    height: 76,
+                    color: const Color(0xffa2a2a2),
+                  ),
+                  const Column(
+                    children: [
+                      Text(
+                        '퀴즈 정답률',
+                        style: TextStyle(
+                          color: Color(0xFF4A4A4A),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 0.80,
+                        ),
+                      ),
+                      SizedBox(
+                        height: 9,
+                      ),
+                      // 퀴즈 정답률
+                      Text(
+                        '75%',
+                        style: TextStyle(
+                          color: Color(0xFF2AD6D6),
+                          fontSize: 24,
+                          fontWeight: FontWeight.w700,
+                          height: 1.30,
+                          letterSpacing: -0.60,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(
+              height: 28,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 5),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: List.generate(7, (index) {
+                  final days = ['일', '월', '화', '수', '목', '금', '토'];
+                  return DailyCheck(
+                    day: days[index],
+                    isChecked: controller.isCheckedList[index], // 첫 번째 항목만 true
+                  );
+                }),
+              ),
+            ),
+            const SizedBox(
+              height: 28,
+            ),
+            const MyContentsContainer(
+              title: '나의 학습',
+              subTitle: '스크랩 한 퀴즈, 학습, 틀린 문제를 확인해요',
+            ),
+            const SizedBox(
+              height: 12,
+            ),
+            const MyContentsContainer(
+              title: '커뮤니티 활동',
+              subTitle: '스크랩 및 좋아요 한 커뮤니티 내용을 확인해요',
+            ),
+            const SizedBox(
+              height: 12,
+            ),
+            const MyContentsContainer(
+              title: '스크랩 한 기사',
+              subTitle: '스크랩 한 기사 내용을 확인해요',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MyContentsContainer extends StatelessWidget {
+  final String title;
+  final String subTitle;
+
+  const MyContentsContainer({
+    super.key,
+    required this.title,
+    required this.subTitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width - 32,
+      height: 80,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: ShapeDecoration(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          side: const BorderSide(width: 1, color: Color(0xFFA2A2A2)),
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: Color(0xFF111111),
+              fontSize: 14,
+              fontWeight: FontWeight.w400,
+              height: 1.30,
+              letterSpacing: -0.35,
+            ),
+          ),
+          const SizedBox(
+            height: 4,
+          ),
+          Text(
+            subTitle,
+            style: const TextStyle(
+              color: Color(0xFF404040),
+              fontSize: 12,
+              fontWeight: FontWeight.w400,
+              height: 1.30,
+              letterSpacing: -0.30,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class DailyCheck extends StatelessWidget {
+  final String day;
+  final bool isChecked;
+
+  const DailyCheck({
+    super.key,
+    required this.day,
+    required this.isChecked,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          day,
+          style: const TextStyle(
+            color: Color(0xFF111111),
+            fontSize: 12,
+            fontFamily: 'Noto',
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(
+          height: 6,
+        ),
+        Container(
+          width: 38,
+          height: 38,
+          decoration: ShapeDecoration(
+            color:
+                isChecked ? const Color(0xFF2AD6D6) : const Color(0xfff2f3f5),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(36),
+            ),
+          ),
+          child: Center(
+            child: Container(
+              width: 20,
+              height: 20,
+              padding: const EdgeInsets.all(2),
+              decoration: ShapeDecoration(
+                color: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              child: Icon(
+                Icons.check,
+                color: isChecked
+                    ? const Color(0xFF2AD6D6)
+                    : const Color(0xfff2f3f5),
+                size: 15,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class JobContainer extends StatelessWidget {
+  final String text;
+
+  const JobContainer({
+    super.key,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: ShapeDecoration(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          side: const BorderSide(width: 1, color: Color(0xFFA2A2A2)),
+          borderRadius: BorderRadius.circular(20),
+        ),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(
+          color: Color(0xFF767676),
+          fontSize: 12,
+          fontWeight: FontWeight.w400,
+          height: 1.50,
+          letterSpacing: -0.30,
+        ),
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
+++ b/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
-import 'package:economic_fe/utils/screen_utils.dart';
 import 'package:economic_fe/view/theme/palette.dart';
 import 'package:economic_fe/view/widgets/custom_bottom_bar.dart';
-import 'package:economic_fe/view/widgets/profile_setting/profile_button_unselected.dart';
 import 'package:economic_fe/view_model/mypage/mypage_home_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -340,23 +338,28 @@ class _MypageHomePageState extends State<MypageHomePage> {
             const SizedBox(
               height: 28,
             ),
-            const MyContentsContainer(
+            MyContentsContainer(
               title: '나의 학습',
               subTitle: '스크랩 한 퀴즈, 학습, 틀린 문제를 확인해요',
+              onTap: () {},
             ),
             const SizedBox(
               height: 12,
             ),
-            const MyContentsContainer(
+            MyContentsContainer(
               title: '커뮤니티 활동',
               subTitle: '스크랩 및 좋아요 한 커뮤니티 내용을 확인해요',
+              onTap: () {},
             ),
             const SizedBox(
               height: 12,
             ),
-            const MyContentsContainer(
+            MyContentsContainer(
               title: '스크랩 한 기사',
               subTitle: '스크랩 한 기사 내용을 확인해요',
+              onTap: () {
+                Get.toNamed('/mypage/article');
+              },
             ),
           ],
         ),
@@ -368,54 +371,59 @@ class _MypageHomePageState extends State<MypageHomePage> {
 class MyContentsContainer extends StatelessWidget {
   final String title;
   final String subTitle;
+  final Function() onTap;
 
   const MyContentsContainer({
     super.key,
     required this.title,
     required this.subTitle,
+    required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: MediaQuery.of(context).size.width - 32,
-      height: 80,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: ShapeDecoration(
-        color: Colors.white,
-        shape: RoundedRectangleBorder(
-          side: const BorderSide(width: 1, color: Color(0xFFA2A2A2)),
-          borderRadius: BorderRadius.circular(8),
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: MediaQuery.of(context).size.width - 32,
+        height: 80,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: ShapeDecoration(
+          color: Colors.white,
+          shape: RoundedRectangleBorder(
+            side: const BorderSide(width: 1, color: Color(0xFFA2A2A2)),
+            borderRadius: BorderRadius.circular(8),
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-            title,
-            style: const TextStyle(
-              color: Color(0xFF111111),
-              fontSize: 14,
-              fontWeight: FontWeight.w400,
-              height: 1.30,
-              letterSpacing: -0.35,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                color: Color(0xFF111111),
+                fontSize: 14,
+                fontWeight: FontWeight.w400,
+                height: 1.30,
+                letterSpacing: -0.35,
+              ),
             ),
-          ),
-          const SizedBox(
-            height: 4,
-          ),
-          Text(
-            subTitle,
-            style: const TextStyle(
-              color: Color(0xFF404040),
-              fontSize: 12,
-              fontWeight: FontWeight.w400,
-              height: 1.30,
-              letterSpacing: -0.30,
+            const SizedBox(
+              height: 4,
             ),
-          ),
-        ],
+            Text(
+              subTitle,
+              style: const TextStyle(
+                color: Color(0xFF404040),
+                fontSize: 12,
+                fontWeight: FontWeight.w400,
+                height: 1.30,
+                letterSpacing: -0.30,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
+++ b/economic_fe/lib/view/screens/mypage/mypage_home_page.dart
@@ -58,7 +58,9 @@ class _MypageHomePageState extends State<MypageHomePage> {
           Padding(
             padding: const EdgeInsets.only(right: 20, left: 8),
             child: GestureDetector(
-              onTap: () {}, // 설정 화면으로
+              onTap: () {
+                Get.toNamed('/mypage/setting');
+              }, // 설정 화면으로
               child: const Icon(
                 Icons.settings_outlined,
                 size: 24,

--- a/economic_fe/lib/view/screens/mypage/setting_page.dart
+++ b/economic_fe/lib/view/screens/mypage/setting_page.dart
@@ -1,0 +1,84 @@
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:economic_fe/view/widgets/custom_app_bar.dart';
+import 'package:economic_fe/view/widgets/mypage/category_options.dart';
+import 'package:economic_fe/view/widgets/mypage/category_text.dart';
+import 'package:economic_fe/view_model/mypage/setting_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class SettingPage extends StatefulWidget {
+  const SettingPage({super.key});
+
+  @override
+  State<SettingPage> createState() => _SettingPageState();
+}
+
+class _SettingPageState extends State<SettingPage> {
+  final SettingController controller = Get.put(SettingController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Palette.background,
+      appBar: CustomAppBar(
+        title: '설정 및 약관',
+        icon: Icons.arrow_back_ios_new,
+        onPress: () => Get.back(),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 13.5),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const CategoryText(text: '알림'),
+            Obx(() {
+              return CategoryOptions(
+                text: '전체 알림',
+                onTap: () {
+                  controller.toggle();
+                },
+                isToggle: true,
+                isToggleOn: controller.isToggled.value,
+              );
+            }),
+            const SizedBox(
+              height: 36,
+            ),
+            const CategoryText(text: '약관 및 정보'),
+            CategoryOptions(
+              text: '이용약관',
+              onTap: () {
+                Get.toNamed('/login/agreement/detail');
+              },
+            ),
+            CategoryOptions(
+              text: '버전 정보',
+              isText: true,
+              onTap: () {},
+            ),
+            const SizedBox(
+              height: 28,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 6),
+              child: GestureDetector(
+                onTap: () {},
+                child: const Text(
+                  '회원탈퇴',
+                  style: TextStyle(
+                    color: Color(0xFF767676),
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    decoration: TextDecoration.underline,
+                    height: 1.40,
+                    letterSpacing: -0.40,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view/widgets/custom_bottom_bar.dart
+++ b/economic_fe/lib/view/widgets/custom_bottom_bar.dart
@@ -116,7 +116,7 @@ class CustomBottomBar extends StatelessWidget {
               Get.toNamed('/community'); // 커뮤니티 페이지로 이동
               break;
             case 4:
-              // Get.toNamed('/profile');  // 마이페이지로 이동
+              Get.toNamed('/mypage'); // 마이페이지로 이동
               break;
             default:
               break;

--- a/economic_fe/lib/view/widgets/mypage/category_options.dart
+++ b/economic_fe/lib/view/widgets/mypage/category_options.dart
@@ -1,0 +1,86 @@
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:flutter/material.dart';
+
+class CategoryOptions extends StatelessWidget {
+  final String text;
+  final Function() onTap;
+  final bool? isToggle;
+  final bool? isToggleOn;
+  final bool? isText;
+
+  const CategoryOptions({
+    super.key,
+    required this.text,
+    required this.onTap,
+    this.isToggle = false,
+    this.isToggleOn = true,
+    this.isText = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 6, top: 27.5),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            text,
+            style: const TextStyle(
+              color: Color(0xFF111111),
+              fontSize: 16,
+              fontWeight: FontWeight.w400,
+              height: 1.40,
+              letterSpacing: -0.40,
+            ),
+          ),
+          isToggle!
+              ? GestureDetector(
+                  onTap: onTap, // 버튼 클릭 시 상태 변경
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 300), // 애니메이션 지속 시간
+                    width: 52,
+                    height: 29,
+                    decoration: BoxDecoration(
+                      color: isToggleOn!
+                          ? Palette.buttonColorBlue
+                          : Colors.grey, // 상태에 따른 색상
+                      borderRadius: BorderRadius.circular(25), // 둥근 모서리
+                    ),
+                    alignment: isToggleOn!
+                        ? Alignment.centerRight
+                        : Alignment.centerLeft, // 상태에 따른 위치
+                    padding: const EdgeInsets.all(1.5),
+                    child: Container(
+                      width: 25,
+                      height: 25,
+                      decoration: const BoxDecoration(
+                        color: Colors.white,
+                        shape: BoxShape.circle, // 둥근 토글 버튼
+                      ),
+                    ),
+                  ),
+                )
+              : isText!
+                  ? const Text(
+                      '최신 1.0 사용 중',
+                      style: TextStyle(
+                        color: Color(0xFF767676),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w400,
+                        height: 1.40,
+                        letterSpacing: -0.30,
+                      ),
+                    )
+                  : GestureDetector(
+                      onTap: onTap,
+                      child: const Icon(
+                        Icons.arrow_forward_ios,
+                        size: 15,
+                      ),
+                    ),
+        ],
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view/widgets/mypage/category_text.dart
+++ b/economic_fe/lib/view/widgets/mypage/category_text.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class CategoryText extends StatelessWidget {
+  final String text;
+
+  const CategoryText({
+    super.key,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: Color(0xFF111111),
+        fontSize: 18,
+        fontWeight: FontWeight.w500,
+        height: 1.30,
+        letterSpacing: -0.45,
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view_model/mypage/bookmarked_articles_controller.dart
+++ b/economic_fe/lib/view_model/mypage/bookmarked_articles_controller.dart
@@ -1,0 +1,26 @@
+import 'package:economic_fe/data/models/article.dart';
+import 'package:economic_fe/data/models/article_model.dart';
+import 'package:economic_fe/view/screens/article/article_detail_page.dart';
+import 'package:get/get.dart';
+
+class BookmarkedArticlesController extends GetxController {
+  // 기사 리스트 데이터
+  List<Article> articles = List.generate(
+    10,
+    (index) => Article(
+      id: index,
+      category: '경기 분석',
+      headline: '[속보] 기사 제목 $index',
+      publisher: '경기일보',
+      uploadTime: '4시간 전',
+      isBookmarked: false.obs,
+      url:
+          'https://www.hankookilbo.com/News/Read/A2022022411300004923', // 임시 기사 링크
+    ),
+  );
+
+  // 기사 세부페이지로 이동
+  void toDetailPage(ArticleModel article) {
+    Get.to(() => const ArticleDetailPage(), arguments: article);
+  }
+}

--- a/economic_fe/lib/view_model/mypage/bookmarked_posts_controller.dart
+++ b/economic_fe/lib/view_model/mypage/bookmarked_posts_controller.dart
@@ -1,0 +1,58 @@
+import 'package:get/get.dart';
+
+class BookmarkedPostsController extends GetxController {
+  final String argument = Get.arguments ?? '스크랩 한 글';
+
+  // 게시글 데이터 리스트
+  final RxList<Map<String, String>> posts = <Map<String, String>>[].obs;
+
+  // Mock 데이터
+  final List<Map<String, String>> bookmarkedPosts = [
+    {
+      "category": "일반 게시판",
+      "title": "스크랩한 게시글 제목 1",
+      "uploadTime": "2시간 전",
+    },
+    {
+      "category": "경제 톡톡",
+      "title": "스크랩한 게시글 제목 2",
+      "uploadTime": "1일 전",
+    },
+  ];
+
+  final List<Map<String, String>> likedPosts = [
+    {
+      "category": "일반 게시판",
+      "title": "좋아요한 게시글 제목 1",
+      "uploadTime": "3시간 전",
+    },
+    {
+      "category": "경제 톡톡",
+      "title": "좋아요한 게시글 제목 2",
+      "uploadTime": "2일 전",
+    },
+  ];
+
+  final List<Map<String, String>> likedComments = [
+    {
+      "category": "일반 게시판",
+      "title": "좋아요한 댓글 내용",
+      "uploadTime": "4시간 전",
+      "postTitle": "원문글 제목",
+    },
+  ];
+
+  @override
+  void onInit() {
+    super.onInit();
+
+    // arguments에 따라 posts 초기화
+    if (argument == '스크랩 한 글') {
+      posts.assignAll(bookmarkedPosts);
+    } else if (argument == '좋아요 한 글') {
+      posts.assignAll(likedPosts);
+    } else if (argument == '좋아요 한 댓글') {
+      posts.assignAll(likedComments);
+    }
+  }
+}

--- a/economic_fe/lib/view_model/mypage/my_learning_controller.dart
+++ b/economic_fe/lib/view_model/mypage/my_learning_controller.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class MyLearningController extends GetxController
+    with GetSingleTickerProviderStateMixin {
+  late TabController tabController;
+
+  // 탭별 데이터
+  final List<Map<String, dynamic>> quizzes = [
+    {'category': '금융', 'title': '저축과 이자'},
+    {'category': '경제', 'title': '수요와 공급'},
+  ];
+
+  final List<Map<String, dynamic>> learningMaterials = [
+    {'category': '금융', 'title': '주식의 기초'},
+    {'category': '경제', 'title': '물가와 환율'},
+  ];
+
+  final List<Map<String, dynamic>> incorrectQuestions = [
+    {'category': '금융', 'title': '복리 계산'},
+    {'category': '경제', 'title': 'GDP와 GNI'},
+  ];
+
+  // 현재 선택된 탭 데이터
+  RxList<Map<String, dynamic>> currentData = <Map<String, dynamic>>[].obs;
+
+  // 현재 선택된 레벨
+  RxString selectedLevel = '초급'.obs;
+
+  // 버튼 텍스트
+  RxString buttonText = '스크랩 한 모든 퀴즈 다시 풀기'.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    tabController = TabController(length: 3, vsync: this);
+
+    // 초기 데이터 설정
+    updateCurrentData(0);
+
+    // 탭 변경 시 데이터와 버튼 텍스트 업데이트
+    tabController.addListener(() {
+      if (tabController.indexIsChanging) {
+        updateCurrentData(tabController.index);
+      }
+    });
+  }
+
+  void updateCurrentData(int index) {
+    switch (index) {
+      case 0:
+        currentData.assignAll(quizzes);
+        buttonText.value = '스크랩 한 모든 퀴즈 다시 풀기';
+        break;
+      case 1:
+        currentData.assignAll(learningMaterials);
+        buttonText.value = '스크랩 한 모든 학습 다시 보기';
+        break;
+      case 2:
+        currentData.assignAll(incorrectQuestions);
+        buttonText.value = '틀린 모든 문제 다시 풀기';
+        break;
+    }
+  }
+
+  void updateSelectedLevel(String level) {
+    selectedLevel.value = level;
+  }
+}

--- a/economic_fe/lib/view_model/mypage/mypage_home_controller.dart
+++ b/economic_fe/lib/view_model/mypage/mypage_home_controller.dart
@@ -1,0 +1,20 @@
+import 'package:economic_fe/data/services/image_picker_service.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class MypageHomeController extends GetxController {
+  final ImagePickerService _imagePickerService = ImagePickerService();
+  var selectedProfileImage = Rx<String?>(null);
+
+  // 프로필 사진 선택 함수
+  Future<void> selectProfileImage(BuildContext context) async {
+    final image = await _imagePickerService.showImagePickerDialog(context);
+    if (image != null) {
+      selectedProfileImage.value = image.path; // 이미지 경로 저장
+      print('Selected image path: ${image.path}');
+    }
+  }
+
+  // 요일 체크 상태 관리
+  var isCheckedList = <bool>[true, true, false, true, true, true, false].obs;
+}

--- a/economic_fe/lib/view_model/mypage/setting_controller.dart
+++ b/economic_fe/lib/view_model/mypage/setting_controller.dart
@@ -1,0 +1,10 @@
+import 'package:get/get.dart';
+
+class SettingController extends GetxController {
+  // 알림 토글 관리
+  var isToggled = true.obs;
+
+  void toggle() {
+    isToggled.value = !isToggled.value;
+  }
+}

--- a/economic_fe/lib/view_model/profile_setting/basic_controller.dart
+++ b/economic_fe/lib/view_model/profile_setting/basic_controller.dart
@@ -41,85 +41,13 @@ class BasicController extends GetxController {
     Get.toNamed('/profile_setting');
   }
 
-  // 프로필 사진 선택 함수 (갤러리 또는 카메라)
+  // 프로필 사진 선택 함수
   Future<void> selectProfileImage(BuildContext context) async {
-    // 이미지 선택 다이얼로그
-    await showDialog(
-      context: context,
-      builder: (context) {
-        return Dialog(
-          backgroundColor: Colors.white,
-          child: Container(
-            padding: const EdgeInsets.symmetric(vertical: 25, horizontal: 27),
-            child: Column(
-              mainAxisSize: MainAxisSize.min, // 다이얼로그 크기를 내용에 맞게 조정
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  '프로필 사진',
-                  style: TextStyle(
-                    color: Color(0xFF111111),
-                    fontSize: 24,
-                    fontWeight: FontWeight.w600,
-                    height: 1.30,
-                    letterSpacing: -0.60,
-                  ),
-                ),
-                const SizedBox(
-                  height: 25.5,
-                ),
-                // 사진첩 버튼
-                GestureDetector(
-                  onTap: () async {
-                    Navigator.pop(context);
-                    var image =
-                        await _imagePickerService.pickImageFromGallery();
-                    if (image != null) {
-                      selectedProfileImage.value = image.path; // 이미지 경로 저장
-                      print('Selected image path: ${image.path}');
-                    }
-                  },
-                  child: const Text(
-                    '사진첩',
-                    style: TextStyle(
-                      color: Color(0xFF111111),
-                      fontSize: 20,
-                      fontWeight: FontWeight.w400,
-                      height: 1.30,
-                      letterSpacing: -0.50,
-                    ),
-                  ),
-                ),
-                const SizedBox(
-                  height: 28,
-                ),
-                // 카메라 버튼
-                GestureDetector(
-                  onTap: () async {
-                    Navigator.pop(context);
-                    var image = await _imagePickerService.pickImageFromCamera();
-                    if (image != null) {
-                      selectedProfileImage.value = image.path; // 이미지 경로 저장
-                      print('Captured image path: ${image.path}');
-                    }
-                  },
-                  child: const Text(
-                    '카메라',
-                    style: TextStyle(
-                      color: Color(0xFF111111),
-                      fontSize: 20,
-                      fontWeight: FontWeight.w400,
-                      height: 1.30,
-                      letterSpacing: -0.50,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
+    final image = await _imagePickerService.showImagePickerDialog(context);
+    if (image != null) {
+      selectedProfileImage.value = image.path; // 이미지 경로 저장
+      print('Selected image path: ${image.path}');
+    }
   }
 
   // 닉네임 유효성 검사

--- a/economic_fe/pubspec.lock
+++ b/economic_fe/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -380,18 +380,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -580,7 +580,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -593,10 +593,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -737,10 +737,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:

--- a/economic_fe/pubspec.yaml
+++ b/economic_fe/pubspec.yaml
@@ -92,6 +92,9 @@ flutter:
     - family: Palanquin
       fonts:
         - asset: assets/fonts/PalanquinDark-Regular.ttf
+    - family: Noto
+      fonts:
+        - asset: assets/fonts/NotoSansKR-Medium.ttf
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #58 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 마이페이지 홈 화면 구성
    - 프로필 사진 설정 메서드 분리 (ImagePickerService)
- 스크랩한 기사 목록 화면 구성
- 커뮤니티 활동 홈 화면 구성
- 설정 및 약관 화면 구성
    - CategoryText, CategoryOptions 위젯으로 분리
    - 알림 설정 토글 버튼으로 구현
- 나의 학습 화면 구성

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<table>
<tr><td>마이페이지 홈</td><td>나의 학습</td></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/2abc224c-70ef-440e-a5ee-0bc9fd62b109" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/6ca1180c-4f9e-4c2c-9bf2-f778956ea3e4" width="150"></td>
</tr></table>
<table>
<tr><td>커뮤니티 활동</td><td>스크랩 한 글</td><td>스크랩 한 기사</td></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/2f261077-51b4-4d1b-9068-dd0317d36b7c" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/385a6de2-8c41-4f3b-8f2e-e0a0085a22f9" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/da9ed2c2-8b0f-4de1-bdd6-204219840af4" width="150"></td>
</tr></table>
