### PR TITLE
feat: 카카오 로그인 연동 및 토큰 저장

### DIFF
--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -643,4 +643,23 @@ class RemoteDataSource {
       return false;
     }
   }
+
+  /// api/v2/auth/login/kakao
+  /// 카카오 로그인 (v2)
+  static Future<dynamic> getlogin(String accessToken) async {
+    String endPoint = "api/v2/auth/login/kakao?accessToken=$accessToken";
+    try {
+      final response = await _getApi(endPoint);
+
+      if (response != null) {
+        debugPrint("성공");
+        return response;
+      } else {
+        debugPrint("실패");
+        return null;
+      }
+    } catch (e) {
+      debugPrint('Error : $e');
+    }
+  }
 }

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -49,6 +49,45 @@ class RemoteDataSource {
   /// API POST
   ///
   /// 데이터 생성시 사용
+  /// jsonData 포함O
+  /// 앱에 저장된 accessToken 사용
+  Future<dynamic> postApiWithJsonTest(
+    String endPoint,
+    Map<String, dynamic> jsonData,
+  ) async {
+    String apiUrl = '$baseUrl/$endPoint';
+
+    String? access = await getToken("accessToken");
+
+    Map<String, String> headers = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $access',
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse(apiUrl),
+        headers: headers,
+        body: jsonEncode(jsonData),
+      );
+
+      if (response.statusCode == 200) {
+        debugPrint('POST 요청 성공');
+        return response.statusCode;
+      } else {
+        debugPrint('POST 요청 실패: (${response.statusCode}) ${response.body}');
+      }
+
+      return response.statusCode;
+    } catch (e) {
+      debugPrint('POST 요청 중 예외 발생: $e');
+      return null;
+    }
+  }
+
+  /// API POST
+  ///
+  /// 데이터 생성시 사용
   /// jsonData 포함X
   static Future<dynamic> _postApi(
     String endPoint,
@@ -59,6 +98,43 @@ class RemoteDataSource {
     Map<String, String> headers = {
       'Content-Type': 'application/json',
       'Authorization': 'Bearer $accessToken',
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse(apiUrl),
+        headers: headers,
+        // body: jsonEncode(jsonData),
+      );
+
+      if (response.statusCode == 200) {
+        debugPrint('POST 요청 성공');
+        return response.statusCode;
+      } else {
+        debugPrint('POST 요청 실패: (${response.statusCode}) ${response.body}');
+      }
+
+      return response.statusCode;
+    } catch (e) {
+      debugPrint('POST 요청 중 예외 발생: $e');
+      return null;
+    }
+  }
+
+  /// API POST
+  ///
+  /// 데이터 생성시 사용
+  /// jsonData 포함X
+  /// 앱에 저장된 accessToken 사용
+  Future<dynamic> _postApiTest(
+    String endPoint,
+  ) async {
+    String apiUrl = '$baseUrl/$endPoint';
+    String? access = await getToken("accessToken");
+    // String authToken = dotenv.env['AUTHORIZATION_KEY']!; // 환경 변수에서 가져오기
+    Map<String, String> headers = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $access',
     };
 
     try {
@@ -213,6 +289,37 @@ class RemoteDataSource {
     try {
       final headers = {
         'Authorization': 'Bearer $accessToken',
+        'accept': '*/*',
+      };
+      final response = await http.delete(
+        Uri.parse(apiUrl),
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        debugPrint('DELETE 요청 성공');
+      } else {
+        debugPrint('DELETE 요청 실패: (${response.statusCode})${response.body}');
+      }
+
+      return response.statusCode;
+    } catch (e) {
+      debugPrint('DELETE 요청 중 예외 발생: $e');
+      return;
+    }
+  }
+
+  /// API DELETE
+  ///
+  /// 데이터 삭제시 사용
+  /// 앱에 저장된 accessToken 사용
+  Future<dynamic> _deleteApiTest(String endPoint) async {
+    String apiUrl = '$baseUrl/$endPoint';
+    debugPrint('DELETE 요청: $endPoint');
+    String? access = await getToken("accessToken");
+    try {
+      final headers = {
+        'Authorization': 'Bearer $access',
         'accept': '*/*',
       };
       final response = await http.delete(

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 
 class RemoteDataSource {
   //기본 api 엔드포인트
@@ -164,6 +165,44 @@ class RemoteDataSource {
     }
   }
 
+  /// API GET (token 사용)
+  ///
+  /// 데이터 받아올 때 사용
+  /// 앱에 저장된 accessToken 사용
+  Future<dynamic> _getApiWithHeaderTest(
+      String endPoint, String accessToken) async {
+    String apiUrl = '$baseUrl/$endPoint';
+    debugPrint('GET 요청: $endPoint');
+
+    String? access = await getToken("accessToken");
+
+    try {
+      final headers = {
+        'Authorization': 'Bearer $access',
+        'accept': '*/*',
+      };
+      final response = await http.get(
+        Uri.parse(apiUrl),
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        debugPrint('GET 요청 성공');
+
+        // return jsonDecode(response.body);
+        // 한글 깨지지 않도록 설정
+        final decodedResponse = jsonDecode(utf8.decode(response.bodyBytes));
+        return decodedResponse;
+      } else {
+        debugPrint('GET 요청 실패: (${response.statusCode})${response.body}');
+        return response;
+      }
+    } catch (e) {
+      debugPrint('GET 요청 중 예외 발생: $e');
+      return;
+    }
+  }
+
   /// API DELETE
   ///
   /// 데이터 삭제시 사용
@@ -194,12 +233,28 @@ class RemoteDataSource {
     }
   }
 
+  // 토큰 저장
+  Future<void> saveToken(String sessionKey, String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(sessionKey, token);
+  }
+
+  // 토큰 불러오기
+  Future<String?> getToken(String sessionKey) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(sessionKey);
+  }
+
+  // 토큰 삭제
+  Future<void> deleteToken(String sessionKey) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(sessionKey);
+  }
+
   /// 개념 학습 세트 조회
   /// api/v1/learning/{learningSetId}/concepts
-  /// api/v1/learning/1/concepts?level=BEGINNER
-  static Future<dynamic> getLearningConcept(
-      int learningSetId, String level) async {
-    dynamic response = await _getApiWithHeader(
+  Future<dynamic> getLearningConcept(int learningSetId, String level) async {
+    dynamic response = await _getApiWithHeaderTest(
         'api/v1/learning/$learningSetId/concepts?level=$level', accessToken);
     print(response);
     return response;
@@ -236,16 +291,15 @@ class RemoteDataSource {
 
   /// 뉴스 목록 조회
   /// api/news
-  static Future<dynamic> getNewsList(
-      int page, String sort, String? category) async {
+  Future<dynamic> getNewsList(int page, String sort, String? category) async {
     dynamic response;
     if (category != null) {
-      response = await _getApiWithHeader(
+      response = await _getApiWithHeaderTest(
         'api/news?page=$page&sort=$sort&category=$category',
         accessToken,
       );
     } else {
-      response = await _getApiWithHeader(
+      response = await _getApiWithHeaderTest(
         'api/news?page=$page&sort=$sort',
         accessToken,
       );
@@ -303,13 +357,13 @@ class RemoteDataSource {
 
   /// 자음 별 용어 조회
   /// api/v1/terms/search/consonant
-  static Future<dynamic> getDictionary(int page, String consonant) async {
+  Future<dynamic> getDictionary(int page, String consonant) async {
     dynamic response;
 
     // 한글 자음을 URL 인코딩
     String encodedConsonant = Uri.encodeComponent(consonant);
 
-    response = await _getApiWithHeader(
+    response = await _getApiWithHeaderTest(
         'api/v1/terms/search/consonant?page=$page&consonant=$encodedConsonant',
         accessToken);
 
@@ -323,10 +377,10 @@ class RemoteDataSource {
 
   /// 용어 상세 조회
   /// api/v1/terms/{id}
-  static Future<dynamic> getDetailTerms(int id) async {
+  Future<dynamic> getDetailTerms(int id) async {
     dynamic response;
 
-    response = await _getApiWithHeader('api/v1/terms/$id', accessToken);
+    response = await _getApiWithHeaderTest('api/v1/terms/$id', accessToken);
 
     if (response != null) {
       print("용어 상세 : $response");
@@ -339,13 +393,13 @@ class RemoteDataSource {
 
   /// 키워드 별 용어 조회
   /// api/v1/terms/search/keyword
-  static Future<dynamic> getKewordResult(int page, String keyword) async {
+  Future<dynamic> getKewordResult(int page, String keyword) async {
     dynamic response;
 
     // 한글을 URL 인코딩
     String encodedkeyword = Uri.encodeComponent(keyword);
 
-    response = await _getApiWithHeader(
+    response = await _getApiWithHeaderTest(
         'api/v1/terms/search/keyword?page=$page&keyword=$encodedkeyword',
         accessToken);
 
@@ -402,11 +456,11 @@ class RemoteDataSource {
 
   /// 틀린 문제 데이터 요청
   /// api/v1/user/wrong-quizzes
-  static Future<dynamic> fetchIncorrectQuestions(String level) async {
+  Future<dynamic> fetchIncorrectQuestions(String level) async {
     String endpoint = 'api/v1/user/wrong-quizzes?level=$level';
 
     try {
-      final response = await _getApiWithHeader(endpoint, accessToken);
+      final response = await _getApiWithHeaderTest(endpoint, accessToken);
 
       if (response != null && response['isSuccess'] == true) {
         debugPrint('틀린 문제 데이터 요청 성공');
@@ -423,13 +477,13 @@ class RemoteDataSource {
 
   /// 개별 퀴즈 조회
   /// API: api/v1/learning/learning/quiz/{quizId}
-  static Future<dynamic> fetchQuizById(int quizId) async {
+  Future<dynamic> fetchQuizById(int quizId) async {
     try {
       // API Endpoint 구성
       String endPoint = 'api/v1/learning/learning/quiz/$quizId';
 
       // GET 요청 수행
-      final response = await _getApiWithHeader(endPoint, accessToken);
+      final response = await _getApiWithHeaderTest(endPoint, accessToken);
 
       // 응답 데이터 처리
       if (response != null) {
@@ -447,10 +501,10 @@ class RemoteDataSource {
 
   /// 스크랩 한 게시물 조회
   /// API: api/v1/user/scrap-posts
-  static Future<dynamic> fetchScrapedPosts() async {
+  Future<dynamic> fetchScrapedPosts() async {
     const String endPoint = 'api/v1/user/scrap-posts';
 
-    final response = await _getApiWithHeader(endPoint, accessToken);
+    final response = await _getApiWithHeaderTest(endPoint, accessToken);
 
     if (response != null && response['isSuccess']) {
       debugPrint("스크랩 게시글 목록 응답: ${response['results']}");
@@ -463,10 +517,10 @@ class RemoteDataSource {
 
   /// 좋아요 한 게시물 조회
   /// API: api/v1/user/like-posts
-  static Future<dynamic> fetchLikedPosts() async {
+  Future<dynamic> fetchLikedPosts() async {
     const String endPoint = 'api/v1/user/like-posts';
 
-    final response = await _getApiWithHeader(endPoint, accessToken);
+    final response = await _getApiWithHeaderTest(endPoint, accessToken);
 
     if (response != null && response['isSuccess']) {
       debugPrint("좋아요 게시글 목록 응답: ${response['results']}");
@@ -479,10 +533,10 @@ class RemoteDataSource {
 
   /// 좋아요 한 댓글 조회
   /// API: api/v1/user/like-comments
-  static Future<dynamic> fetchLikedComments() async {
+  Future<dynamic> fetchLikedComments() async {
     const String endPoint = 'api/v1/user/like-comments';
 
-    final response = await _getApiWithHeader(endPoint, accessToken);
+    final response = await _getApiWithHeaderTest(endPoint, accessToken);
 
     if (response != null && response['isSuccess']) {
       debugPrint("좋아요 댓글 목록 응답: ${response['results']}");
@@ -495,12 +549,12 @@ class RemoteDataSource {
 
   /// 스크랩 한 개념 학습 조회
   /// API: api/v1/user/scrap-concepts
-  static Future<dynamic> getScrapConcepts(String level) async {
+  Future<dynamic> getScrapConcepts(String level) async {
     String endpoint = 'api/v1/user/scrap-concepts?level=$level';
 
     try {
       // _getApiWithHeader 호출
-      final response = await _getApiWithHeader(endpoint, accessToken);
+      final response = await _getApiWithHeaderTest(endpoint, accessToken);
 
       if (response != null && response is Map<String, dynamic>) {
         debugPrint('스크랩한 학습 데이터 로드 성공');
@@ -517,12 +571,12 @@ class RemoteDataSource {
 
   /// 스크랩 한 퀴즈 조회
   /// API: api/v1/user/scrap-quizzes
-  static Future<dynamic> getScrapQuizzes(String level) async {
+  Future<dynamic> getScrapQuizzes(String level) async {
     String endpoint = 'api/v1/user/scrap-quizzes?level=$level';
 
     try {
       // _getApiWithHeader 호출
-      final response = await _getApiWithHeader(endpoint, accessToken);
+      final response = await _getApiWithHeaderTest(endpoint, accessToken);
 
       if (response != null && response is Map<String, dynamic>) {
         debugPrint('스크랩한 퀴즈 데이터 로드 성공');
@@ -539,12 +593,12 @@ class RemoteDataSource {
 
   /// 레벨별 학습 진도율 조회
   /// API: api/v1/user/progress
-  static Future<dynamic> getProgress() async {
+  Future<dynamic> getProgress() async {
     String endpoint = 'api/v1/user/progress';
 
     try {
       // _getApiWithHeader 호출
-      final response = await _getApiWithHeader(endpoint, accessToken);
+      final response = await _getApiWithHeaderTest(endpoint, accessToken);
 
       if (response != null && response is Map<String, dynamic>) {
         debugPrint('학습 진도율 데이터 로드 성공');
@@ -583,12 +637,12 @@ class RemoteDataSource {
 
   /// api/v1/chatbot/list
   /// 대화 내역 조회
-  static Future<dynamic> getMessageList(int page) async {
+  Future<dynamic> getMessageList(int page) async {
     String endPoint = 'api/v1/chatbot/list?page=$page';
 
     try {
       // _getApiWithHeader 호출
-      final response = await _getApiWithHeader(endPoint, accessToken);
+      final response = await _getApiWithHeaderTest(endPoint, accessToken);
 
       if (response != null && response is Map<String, dynamic>) {
         debugPrint('대화 내역 조회 성공');

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -369,11 +369,11 @@ class RemoteDataSource {
 
   /// api/v1/learning
   /// 레벨별 학습 세트 조회
-  static Future<dynamic> postLearningSet() async {
+  Future<dynamic> postLearningSet() async {
     String endPoint = 'api/v1/learning';
 
     try {
-      final response = await _postApi(endPoint); // API 요청
+      final response = await _postApiTest(endPoint); // API 요청
       print("Raw Response: $response");
 
       if (response is http.Response) {
@@ -422,11 +422,11 @@ class RemoteDataSource {
 
   /// api/news/{id}/scrap
   /// 뉴스 스크랩
-  static Future<dynamic> postNewsScrap(int id) async {
+  Future<dynamic> postNewsScrap(int id) async {
     String endPoint = "api/news/$id/scrap";
 
     try {
-      final response = await _postApi(endPoint);
+      final response = await _postApiTest(endPoint);
 
       if (response != null) {
         debugPrint("스크랩 post 성공");
@@ -443,11 +443,11 @@ class RemoteDataSource {
 
   /// 뉴스 스크랩 취소
   /// api/news/{id}/scrap
-  static Future<dynamic> deleteNewsScrap(int id) async {
+  Future<dynamic> deleteNewsScrap(int id) async {
     String endPoint = "api/news/$id/scrap";
 
     try {
-      final response = await _deleteApi(endPoint);
+      final response = await _deleteApiTest(endPoint);
 
       if (response != null) {
         debugPrint("스크랩 delete 성공");
@@ -521,11 +521,11 @@ class RemoteDataSource {
 
   /// api/v1/terms/{id}/scrap
   /// 용어 스크랩
-  static Future<dynamic> postTermsScrap(int id) async {
+  Future<dynamic> postTermsScrap(int id) async {
     String endPoint = "api/v1/terms/$id/scrap";
 
     try {
-      final response = await _postApi(endPoint);
+      final response = await _postApiTest(endPoint);
 
       if (response != null) {
         debugPrint("스크랩 post 성공");
@@ -542,11 +542,11 @@ class RemoteDataSource {
 
   /// api/v1/terms/{id}/scrap
   /// 용어 스크랩 취소
-  static Future<dynamic> deleteScrap(int id) async {
+  Future<dynamic> deleteScrap(int id) async {
     String endPoint = "api/v1/terms/$id/scrap";
 
     try {
-      final response = await _deleteApi(endPoint);
+      final response = await _deleteApiTest(endPoint);
 
       if (response != null) {
         debugPrint("스크랩 delete 성공");
@@ -722,12 +722,11 @@ class RemoteDataSource {
 
   /// 사용자 프로필 등록 API
   /// API: api/v1/user/profile
-  static Future<dynamic> registerUserProfile(
-      Map<String, dynamic> userProfile) async {
+  Future<dynamic> registerUserProfile(Map<String, dynamic> userProfile) async {
     String endpoint = 'api/v1/user/profile';
 
     try {
-      final response = await postApiWithJson(endpoint, userProfile);
+      final response = await postApiWithJsonTest(endpoint, userProfile);
 
       if (response == 200) {
         debugPrint('사용자 프로필 등록 성공');
@@ -766,11 +765,11 @@ class RemoteDataSource {
 
   /// api/v1/chatbot
   /// 챗봇에게 메세지 보내기
-  static Future<dynamic> postChatbotMessage(String message) async {
+  Future<dynamic> postChatbotMessage(String message) async {
     String encodedmsg = Uri.encodeComponent(message);
     String endPoint = "api/v1/chatbot?message=$encodedmsg";
     try {
-      final response = await _postApi(endPoint);
+      final response = await _postApiTest(endPoint);
 
       if (response != null) {
         debugPrint("대화 전송 성공");
@@ -786,11 +785,11 @@ class RemoteDataSource {
 
   /// api/v1/chatbot/clear
   /// 대화 내역 초기화
-  static Future<bool> deleteMessage() async {
+  Future<bool> deleteMessage() async {
     String endPoint = "api/v1/chatbot/clear";
 
     try {
-      final response = await _deleteApi(endPoint);
+      final response = await _deleteApiTest(endPoint);
 
       if (response != null) {
         debugPrint("메시지 delete 성공");

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/chatbot',
+      initialRoute: '/login_exist',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class ArticleListController extends GetxController {
+  final remoteDataSource = RemoteDataSource();
   var selectedSort = "RECENT".obs;
   var selectedCate = "전체".obs;
 
@@ -38,15 +39,17 @@ class ArticleListController extends GetxController {
   //뉴스 기사 목록 불러오기
   Future<List<ArticleModel>> getNewsList(
       int page, String sort, String? category) async {
+    // final remoteDataSource = RemoteDataSource();
+
     try {
       print("start");
       dynamic response;
 
       if (category != null) {
-        response = await RemoteDataSource.getNewsList(page, sort, category);
+        response = await remoteDataSource.getNewsList(page, sort, category);
         print("category != null $response");
       } else if (category == null || selectedCate == "전체") {
-        response = await RemoteDataSource.getNewsList(page, sort, null);
+        response = await remoteDataSource.getNewsList(page, sort, null);
         print("n : $response");
       }
 

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -68,7 +68,7 @@ class ArticleListController extends GetxController {
       print("start");
       dynamic response;
 
-      response = await RemoteDataSource.postNewsScrap(id);
+      response = await remoteDataSource.postNewsScrap(id);
       print("뉴스 스크랩 : $response");
     } catch (e) {
       debugPrint("Error: $e");

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class ArticleListController extends GetxController {
-  var selectedSort = "RECENT".obs; //
+  var selectedSort = "RECENT".obs;
   var selectedCate = "전체".obs;
 
   // 현재 선택된 카테고리 인덱스
@@ -14,7 +14,6 @@ class ArticleListController extends GetxController {
 
   // 카테고리 탭 클릭 시 선택된 카테고리 인덱스 업데이트
   void selectCategory(String index) {
-    // selectedCategoryIndex.value = idx;
     selectedCate.value = index;
   }
 
@@ -26,31 +25,10 @@ class ArticleListController extends GetxController {
     selectedOrder.value = index;
   }
 
-  // 기사 리스트 데이터
-  // List<Article> articles = List.generate(
-  //   10,
-  //   (index) => Article(
-  //     id: index,
-  //     category: '경기 분석',
-  //     headline: '[속보] 기사 제목 $index',
-  //     publisher: '경기일보',
-  //     uploadTime: '4시간 전',
-  //     isBookmarked: false.obs,
-  //     url:
-  //         'https://www.hankookilbo.com/News/Read/A2022022411300004923', // 임시 기사 링크
-  //   ),
-  // );
-
   // 기사 세부페이지로 이동
   void toDetailPage(ArticleModel article) {
     Get.to(() => const ArticleDetailPage(), arguments: article);
   }
-
-  // 북마크 상태 토글 메서드
-  // void toggleBookmark(int articleId) {
-  //   final article = articles.firstWhere((article) => article.id == articleId);
-  //   article.isBookmarked.value = !article.isBookmarked.value;
-  // }
 
   // 챗봇 화면으로 이동
   void toChatbot() {

--- a/economic_fe/lib/view_model/article/article_list_controller.dart
+++ b/economic_fe/lib/view_model/article/article_list_controller.dart
@@ -81,7 +81,7 @@ class ArticleListController extends GetxController {
       print("start");
 
       dynamic response;
-      response = await RemoteDataSource.deleteNewsScrap(id);
+      response = await remoteDataSource.deleteNewsScrap(id);
       print("scrap delete response : $response");
     } catch (e) {
       debugPrint("Error : $e");

--- a/economic_fe/lib/view_model/chatbot_controller.dart
+++ b/economic_fe/lib/view_model/chatbot_controller.dart
@@ -6,6 +6,8 @@ import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 
 class ChatbotController extends GetxController {
+  final remoteDataSource = RemoteDataSource();
+
   // 메시지 리스트
   var messages = <Message>[].obs;
   var currentPage = 0.obs;
@@ -143,7 +145,7 @@ class ChatbotController extends GetxController {
   Future<List<ChatbotModel>> getChatbotList(int page) async {
     try {
       print("start");
-      dynamic response = await RemoteDataSource.getMessageList(page);
+      dynamic response = await remoteDataSource.getMessageList(page);
 
       print("response :: $response");
       final data = response as Map<String, dynamic>;

--- a/economic_fe/lib/view_model/chatbot_controller.dart
+++ b/economic_fe/lib/view_model/chatbot_controller.dart
@@ -177,7 +177,7 @@ class ChatbotController extends GetxController {
     try {
       print("start");
 
-      dynamic response = await RemoteDataSource.deleteMessage();
+      dynamic response = await remoteDataSource.deleteMessage();
       if (response != null) {
         print("response : $response");
       }

--- a/economic_fe/lib/view_model/chatbot_controller.dart
+++ b/economic_fe/lib/view_model/chatbot_controller.dart
@@ -165,7 +165,7 @@ class ChatbotController extends GetxController {
     try {
       print("start");
 
-      dynamic response = await RemoteDataSource.postChatbotMessage(message);
+      dynamic response = await remoteDataSource.postChatbotMessage(message);
       print("메시지 전송 : $response");
     } catch (e) {
       debugPrint("Error : $e");

--- a/economic_fe/lib/view_model/dictionary_controller.dart
+++ b/economic_fe/lib/view_model/dictionary_controller.dart
@@ -85,7 +85,7 @@ class DictionaryController extends GetxController {
       print("start");
 
       dynamic response;
-      response = await RemoteDataSource.postTermsScrap(id);
+      response = await remoteDataSource.postTermsScrap(id);
       print("scrap response : $response");
     } catch (e) {
       debugPrint("Error: $e");

--- a/economic_fe/lib/view_model/dictionary_controller.dart
+++ b/economic_fe/lib/view_model/dictionary_controller.dart
@@ -98,7 +98,7 @@ class DictionaryController extends GetxController {
       print("start");
 
       dynamic response;
-      response = await RemoteDataSource.deleteScrap(id);
+      response = await remoteDataSource.deleteScrap(id);
       print("scrap delete response : $response");
     } catch (e) {
       debugPrint("Error : $e");

--- a/economic_fe/lib/view_model/dictionary_controller.dart
+++ b/economic_fe/lib/view_model/dictionary_controller.dart
@@ -7,6 +7,8 @@ import 'package:get/get.dart';
 import 'package:go_router/go_router.dart'; // GoRouter import
 
 class DictionaryController extends GetxController {
+  final remoteDataSource = RemoteDataSource();
+
   late BuildContext context;
 
   var selectedConsonant = "ㄱ".obs;
@@ -27,7 +29,7 @@ class DictionaryController extends GetxController {
       dynamic response;
 
       if (type) {
-        response = await RemoteDataSource.getDictionary(page, text);
+        response = await remoteDataSource.getDictionary(page, text);
         print("response :: $response");
 
         final data = response as Map<String, dynamic>;
@@ -35,7 +37,7 @@ class DictionaryController extends GetxController {
         return termList.map((term) => DictionaryModel.fromJson(term)).toList();
       } else {
         print("검색");
-        response = await RemoteDataSource.getKewordResult(page, text);
+        response = await remoteDataSource.getKewordResult(page, text);
         print("response : $response");
 
         final data = response as Map<String, dynamic>;
@@ -55,7 +57,7 @@ class DictionaryController extends GetxController {
 
       dynamic response;
 
-      response = await RemoteDataSource.getKewordResult(page, keyword);
+      response = await remoteDataSource.getKewordResult(page, keyword);
       print("response : $response");
       // final data = response as Map<String, dynamic>;
     } catch (e) {
@@ -70,7 +72,7 @@ class DictionaryController extends GetxController {
 
       dynamic response;
 
-      response = await RemoteDataSource.getDetailTerms(id);
+      response = await remoteDataSource.getDetailTerms(id);
       print("respose : $response");
     } catch (e) {
       debugPrint('Error: $e');

--- a/economic_fe/lib/view_model/home_controller.dart
+++ b/economic_fe/lib/view_model/home_controller.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart'; // GoRouter import
 
 class HomeController extends GetxController {
+  final remoteDataSource = RemoteDataSource();
+
   // 진도율 가시성 관리 (레벨테스트 진행 여부에 따른 로직으로 수정 필요)
   var isProgressContainerVisible = true.obs;
 
@@ -61,7 +63,7 @@ class HomeController extends GetxController {
   /// 레벨별 학습 진도율 조회
   Future<void> fetchProgress() async {
     try {
-      final response = await RemoteDataSource.getProgress();
+      final response = await remoteDataSource.getProgress();
 
       if (response != null && response['isSuccess'] == true) {
         final progressData = response['results']['progress'] ?? {};

--- a/economic_fe/lib/view_model/learning_set/learning_list_controller.dart
+++ b/economic_fe/lib/view_model/learning_set/learning_list_controller.dart
@@ -49,13 +49,15 @@ class LearningListController extends GetxController {
 
   Future<List<LearningModel>> getLearningConcept(
       int learningSetId, String level) async {
+    final remoteDataSource = RemoteDataSource();
+
     try {
       print("start");
 
       dynamic response;
 
       response =
-          await RemoteDataSource.getLearningConcept(learningSetId, level);
+          await remoteDataSource.getLearningConcept(learningSetId, level);
 
       print("response :: $response");
 

--- a/economic_fe/lib/view_model/learning_set/learning_list_controller.dart
+++ b/economic_fe/lib/view_model/learning_set/learning_list_controller.dart
@@ -7,6 +7,8 @@ import 'package:get/get.dart';
 import 'package:go_router/go_router.dart'; // GoRouter import
 
 class LearningListController extends GetxController {
+  final remoteDataSource = RemoteDataSource();
+
   //각 아이템의 퀴즈, 개념학습 수행 여부
   var learningState = {
     0: [false, false],
@@ -49,8 +51,6 @@ class LearningListController extends GetxController {
 
   Future<List<LearningModel>> getLearningConcept(
       int learningSetId, String level) async {
-    final remoteDataSource = RemoteDataSource();
-
     try {
       print("start");
 
@@ -80,7 +80,7 @@ class LearningListController extends GetxController {
       print("start");
 
       dynamic response;
-      response = await RemoteDataSource.postLearningSet();
+      response = await remoteDataSource.postLearningSet();
 
       print("learning set : $response");
 

--- a/economic_fe/lib/view_model/login/login_exist_controller.dart
+++ b/economic_fe/lib/view_model/login/login_exist_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -48,22 +49,6 @@ class LoginExistController extends GetxController {
     }
   }
 
-  // 3. 로그인 플로우 실행
-  // void login() async {
-  //   // 카카오 로그인 요청
-  //   await openKakaoLogin();
-
-  //   print("리디렉션 전");
-  //   // 리디렉션 처리: Flutter WebView 또는 외부 브라우저에서 인증 코드 추출 필요
-  //   String? code = await _getAuthorizationCodeFromRedirectUri();
-  //   print("code : $code");
-  //   if (code != null) {
-  //     // 액세스 토큰 요청
-  //     await fetchAccessToken(code);
-  //   } else {
-  //     print("Authorization Code not found.");
-  //   }
-  // }
   void login() async {
     if (await isKakaoTalkInstalled()) {
       try {
@@ -76,6 +61,7 @@ class LoginExistController extends GetxController {
         print("토큰${token.accessToken}");
 
         getlogin(token.accessToken);
+        toArticle();
       } catch (error) {
         print('카카오톡으로 로그인 실패 $error');
 
@@ -147,8 +133,34 @@ class LoginExistController extends GetxController {
 
       response = await RemoteDataSource.getlogin(accessToken);
       print("response :::: ${response['results']}");
+      await saveToken("accessToken", response['results']);
+      // String? access = await getToken("accessToken");
+      // print(access);
     } catch (e) {
       debugPrint("Error : $e");
     }
+  }
+
+  // 토큰 저장
+  Future<void> saveToken(String sessionKey, String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(sessionKey, token);
+  }
+
+  // 토큰 불러오기
+  Future<String?> getToken(String sessionKey) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(sessionKey);
+  }
+
+  // 토큰 삭제
+  Future<void> deleteToken(String sessionKey) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(sessionKey);
+  }
+
+  // 테스트용
+  void toArticle() {
+    Get.toNamed('/article');
   }
 }

--- a/economic_fe/lib/view_model/login/login_exist_controller.dart
+++ b/economic_fe/lib/view_model/login/login_exist_controller.dart
@@ -1,3 +1,4 @@
+import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -69,10 +70,12 @@ class LoginExistController extends GetxController {
         await UserApi.instance.loginWithKakaoTalk();
         print('카카오톡으로 로그인 성공');
         User user = await UserApi.instance.me();
-        print(
-            '사용자 정보 요청 성공${user.id} ${user.kakaoAccount?.profile?.nickname} ${user.kakaoAccount?.email}');
+        // print(
+        //     '사용자 정보 요청 성공${user.id} ${user.kakaoAccount?.profile?.nickname} ${user.kakaoAccount?.email}');
         OAuthToken token = await UserApi.instance.loginWithKakaoTalk();
-        print(token);
+        print("토큰${token.accessToken}");
+
+        getlogin(token.accessToken);
       } catch (error) {
         print('카카오톡으로 로그인 실패 $error');
 
@@ -134,6 +137,18 @@ class LoginExistController extends GetxController {
 
     return authorizationCode; // 추출된 인증 코드 반환
   }
-}
 
-// class WebView {}
+  // 백엔드에서 토큰 받아오기
+  Future<void> getlogin(String accessToken) async {
+    try {
+      print("start");
+
+      dynamic response;
+
+      response = await RemoteDataSource.getlogin(accessToken);
+      print("response :::: ${response['results']}");
+    } catch (e) {
+      debugPrint("Error : $e");
+    }
+  }
+}

--- a/economic_fe/lib/view_model/mypage/bookmarked_posts_controller.dart
+++ b/economic_fe/lib/view_model/mypage/bookmarked_posts_controller.dart
@@ -17,15 +17,17 @@ class BookmarkedPostsController extends GetxController {
 
   /// Get.arguments 값에 따라 다른 API 호출
   Future<void> fetchData() async {
+    final remoteDataSource = RemoteDataSource();
+
     try {
       dynamic response;
 
       if (argument == '스크랩 한 글') {
-        response = await RemoteDataSource.fetchScrapedPosts();
+        response = await remoteDataSource.fetchScrapedPosts();
       } else if (argument == '좋아요 한 글') {
-        response = await RemoteDataSource.fetchLikedPosts();
+        response = await remoteDataSource.fetchLikedPosts();
       } else if (argument == '좋아요 한 댓글') {
-        response = await RemoteDataSource.fetchLikedComments();
+        response = await remoteDataSource.fetchLikedComments();
       } else {
         debugPrint("fetchData Error: 잘못된 argument 값입니다.");
         return;

--- a/economic_fe/lib/view_model/mypage/my_learning_controller.dart
+++ b/economic_fe/lib/view_model/mypage/my_learning_controller.dart
@@ -5,6 +5,8 @@ import 'package:get/get.dart';
 
 class MyLearningController extends GetxController
     with GetSingleTickerProviderStateMixin {
+  final remoteDataSource = RemoteDataSource();
+
   late TabController tabController;
 
   var selectedConsonant = "ㄱ".obs;
@@ -21,9 +23,9 @@ class MyLearningController extends GetxController
     try {
       print("start");
       dynamic response;
-      
+
       if (type) {
-        response = await RemoteDataSource.getDictionary(page, text);
+        response = await remoteDataSource.getDictionary(page, text);
         print("response :: $response");
 
         final data = response as Map<String, dynamic>;
@@ -31,7 +33,7 @@ class MyLearningController extends GetxController
         return termList.map((term) => DictionaryModel.fromJson(term)).toList();
       } else {
         print("검색");
-        response = await RemoteDataSource.getKewordResult(page, text);
+        response = await remoteDataSource.getKewordResult(page, text);
         print("response : $response");
 
         final data = response as Map<String, dynamic>;
@@ -51,7 +53,7 @@ class MyLearningController extends GetxController
 
       dynamic response;
 
-      response = await RemoteDataSource.getKewordResult(page, keyword);
+      response = await remoteDataSource.getKewordResult(page, keyword);
       print("response : $response");
       // final data = response as Map<String, dynamic>;
     } catch (e) {
@@ -66,7 +68,7 @@ class MyLearningController extends GetxController
 
       dynamic response;
 
-      response = await RemoteDataSource.getDetailTerms(id);
+      response = await remoteDataSource.getDetailTerms(id);
       print("respose : $response");
     } catch (e) {
       debugPrint('Error: $e');
@@ -131,7 +133,7 @@ class MyLearningController extends GetxController
   Future<void> fetchScrapConcepts() async {
     try {
       final response =
-          await RemoteDataSource.getScrapConcepts(selectedLevel.value);
+          await remoteDataSource.getScrapConcepts(selectedLevel.value);
       if (response != null && response['isSuccess'] == true) {
         final List<dynamic> rawConcepts =
             response['results']['scrapConceptList'] ?? [];
@@ -151,7 +153,7 @@ class MyLearningController extends GetxController
   Future<void> fetchScrapQuizzes() async {
     try {
       final response =
-          await RemoteDataSource.getScrapQuizzes(selectedLevel.value);
+          await remoteDataSource.getScrapQuizzes(selectedLevel.value);
       if (response != null && response['isSuccess'] == true) {
         final List<dynamic> rawQuizzes =
             response['results']['scrapQuizList'] ?? [];

--- a/economic_fe/lib/view_model/mypage/wrong_quiz_controller.dart
+++ b/economic_fe/lib/view_model/mypage/wrong_quiz_controller.dart
@@ -20,9 +20,11 @@ class WrongQuizController extends GetxController {
 
   // 틀린 문제 가져오기
   Future<void> fetchIncorrectQuestions() async {
+    final remoteDataSource = RemoteDataSource();
+
     try {
       final response =
-          await RemoteDataSource.fetchIncorrectQuestions(selectedLevel.value);
+          await remoteDataSource.fetchIncorrectQuestions(selectedLevel.value);
 
       if (response != null && response['isSuccess'] == true) {
         final failQuizList = response['results']['failQuizList'] as List;

--- a/economic_fe/lib/view_model/profile_setting/profile_setting_controller.dart
+++ b/economic_fe/lib/view_model/profile_setting/profile_setting_controller.dart
@@ -6,6 +6,8 @@ import 'package:economic_fe/view_model/profile_setting/part_select_controller.da
 import 'package:get/get.dart';
 
 class ProfileSettingController extends GetxController {
+  final remoteDataSource = RemoteDataSource();
+
   // 저장 버튼 상태
   var basicSaveButtonClicked = false.obs;
   var jobSaveButtonClicked = false.obs;
@@ -113,7 +115,7 @@ class ProfileSettingController extends GetxController {
     print("🚀 전송 데이터: ${userProfile.value.toJson()}");
 
     bool success =
-        await RemoteDataSource.registerUserProfile(userProfile.value.toJson());
+        await remoteDataSource.registerUserProfile(userProfile.value.toJson());
 
     if (success) {
       Get.snackbar('성공', '프로필 등록이 완료되었습니다.');

--- a/economic_fe/lib/view_model/quiz/quiz_page_controller.dart
+++ b/economic_fe/lib/view_model/quiz/quiz_page_controller.dart
@@ -2,6 +2,8 @@ import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:get/get.dart';
 
 class QuizPageController extends GetxController {
+  final remoteDataSource = RemoteDataSource();
+
   // 학습 중단 확인창 표시 여부 관리
   var isModalVisible = false.obs;
   var quizData = {}.obs;
@@ -21,7 +23,7 @@ class QuizPageController extends GetxController {
   // 퀴즈 데이터 가져오기
   Future<void> fetchQuizById(int quizId) async {
     try {
-      final response = await RemoteDataSource.fetchQuizById(quizId);
+      final response = await remoteDataSource.fetchQuizById(quizId);
       if (response != null && response['isSuccess'] == true) {
         quizData.value = response['results'];
       } else {

--- a/economic_fe/pubspec.lock
+++ b/economic_fe/pubspec.lock
@@ -524,10 +524,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "3c7e73920c694a436afaf65ab60ce3453d91f84208d761fbd83fc21182134d93"
+      sha256: "688ee90fbfb6989c980254a56cb26ebe9bb30a3a2dff439a78894211f73de67a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.5.1"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/economic_fe/pubspec.yaml
+++ b/economic_fe/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   get: ^4.6.5
   flutter_dotenv: ^5.2.1
-  shared_preferences: ^2.3.4
+  shared_preferences: ^2.5.1
   image_picker: ^1.1.2
   intl: ^0.20.1
   webview_flutter: ^4.10.0


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x]  카카오 로그인 (v2) api 연동
- [x] SharedPreferences 사용하여 로그인 이후 앱에 키 저장
- [x] post, get, delete 함수에서 토큰 받는 방식 변경 
- [x] remote_data_source에서 static -> 변경
- [x] 모든 controller에서 객체를 생성하여 호출하는 방식으로 변경


## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #54 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- remote_data_source에서 static -> 변경
- 모든 controller에서 객체를 생성하여 호출하는 방식으로 변경

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
remote_data_source에 있던 기존의 post, delete, get함수들도 일단 남겨뒀습니다!