### PR TITLE
FEAT: 답글 수정 로직 적용

### DIFF
--- a/economic_fe/lib/data/models/community/comment.dart
+++ b/economic_fe/lib/data/models/community/comment.dart
@@ -7,6 +7,7 @@ class Comment {
   int likes;
   bool isLiked;
   bool isAuthor;
+  bool isDeleted;
   List<Comment> replies;
 
   Comment({
@@ -17,6 +18,7 @@ class Comment {
     required this.likes,
     required this.isLiked,
     required this.isAuthor,
+    required this.isDeleted,
     this.replies = const [],
   });
 }

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -570,7 +570,8 @@ class RemoteDataSource {
     String endpoint = 'api/v1/user/wrong-quizzes?level=$level';
 
     try {
-      final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      // final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      final response = await _getApiWithHeader(endpoint, accessToken);
 
       if (response != null && response['isSuccess'] == true) {
         debugPrint('틀린 문제 데이터 요청 성공');
@@ -593,7 +594,8 @@ class RemoteDataSource {
       String endPoint = 'api/v1/learning/learning/quiz/$quizId';
 
       // GET 요청 수행
-      final response = await _getApiWithHeaderTest(endPoint, accessToken);
+      // final response = await _getApiWithHeaderTest(endPoint, accessToken);
+      final response = await _getApiWithHeader(endPoint, accessToken);
 
       // 응답 데이터 처리
       if (response != null) {
@@ -614,7 +616,8 @@ class RemoteDataSource {
   Future<dynamic> fetchScrapedPosts() async {
     const String endPoint = 'api/v1/user/scrap-posts';
 
-    final response = await _getApiWithHeaderTest(endPoint, accessToken);
+    // final response = await _getApiWithHeaderTest(endPoint, accessToken);
+    final response = await _getApiWithHeader(endPoint, accessToken);
 
     if (response != null && response['isSuccess']) {
       debugPrint("스크랩 게시글 목록 응답: ${response['results']}");
@@ -630,7 +633,8 @@ class RemoteDataSource {
   Future<dynamic> fetchLikedPosts() async {
     const String endPoint = 'api/v1/user/like-posts';
 
-    final response = await _getApiWithHeaderTest(endPoint, accessToken);
+    // final response = await _getApiWithHeaderTest(endPoint, accessToken);
+    final response = await _getApiWithHeader(endPoint, accessToken);
 
     if (response != null && response['isSuccess']) {
       debugPrint("좋아요 게시글 목록 응답: ${response['results']}");
@@ -646,7 +650,8 @@ class RemoteDataSource {
   Future<dynamic> fetchLikedComments() async {
     const String endPoint = 'api/v1/user/like-comments';
 
-    final response = await _getApiWithHeaderTest(endPoint, accessToken);
+    // final response = await _getApiWithHeaderTest(endPoint, accessToken);
+    final response = await _getApiWithHeader(endPoint, accessToken);
 
     if (response != null && response['isSuccess']) {
       debugPrint("좋아요 댓글 목록 응답: ${response['results']}");
@@ -664,7 +669,8 @@ class RemoteDataSource {
 
     try {
       // _getApiWithHeader 호출
-      final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      // final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      final response = await _getApiWithHeader(endpoint, accessToken);
 
       if (response != null && response is Map<String, dynamic>) {
         debugPrint('스크랩한 학습 데이터 로드 성공');
@@ -686,7 +692,8 @@ class RemoteDataSource {
 
     try {
       // _getApiWithHeader 호출
-      final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      // final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      final response = await _getApiWithHeader(endpoint, accessToken);
 
       if (response != null && response is Map<String, dynamic>) {
         debugPrint('스크랩한 퀴즈 데이터 로드 성공');
@@ -708,7 +715,8 @@ class RemoteDataSource {
 
     try {
       // _getApiWithHeader 호출
-      final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      // final response = await _getApiWithHeaderTest(endpoint, accessToken);
+      final response = await _getApiWithHeader(endpoint, accessToken);
 
       if (response != null && response is Map<String, dynamic>) {
         debugPrint('학습 진도율 데이터 로드 성공');

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/login_exist',
+      initialRoute: '/community',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/view/screens/community/community_page.dart
+++ b/economic_fe/lib/view/screens/community/community_page.dart
@@ -796,7 +796,7 @@ class ListItem extends StatelessWidget {
                     ),
                   ),
                   Text(
-                    '$comments',
+                    comments < 0 ? '0' : '$comments',
                     style: const TextStyle(
                       color: Color(0xFF767676),
                       fontSize: 12,

--- a/economic_fe/lib/view/screens/community/detail_page.dart
+++ b/economic_fe/lib/view/screens/community/detail_page.dart
@@ -171,7 +171,8 @@ class _DetailPageState extends State<DetailPage> {
                                 const Icon(Icons.chat_bubble_outline,
                                     size: 18, color: Color(0xff767676)),
                                 const SizedBox(width: 5),
-                                Text("${post["commentCount"] ?? 0}"),
+                                Text(
+                                    "${(post["commentCount"] is int ? post["commentCount"] : int.tryParse(post["commentCount"]?.toString() ?? "0"))?.clamp(0, double.infinity) ?? 0}"),
                                 const SizedBox(width: 8),
                                 // 스크랩
                                 Obx(() => GestureDetector(
@@ -280,6 +281,37 @@ class _DetailPageState extends State<DetailPage> {
                           return const SizedBox(); // 일반 댓글 모드일 때는 아무것도 표시 안함
                         }
                       }),
+                      // 대댓글 수정 UI 추가
+                      Obx(() {
+                        if (controller.isEditingReply.value) {
+                          return Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 10, vertical: 8),
+                            margin: const EdgeInsets.only(bottom: 5),
+                            decoration: BoxDecoration(
+                              color: Colors.grey[200],
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                const Text(
+                                  "대댓글 수정 중...",
+                                  style: TextStyle(
+                                      color: Colors.black87, fontSize: 14),
+                                ),
+                                GestureDetector(
+                                  onTap: controller.disableReplyEditMode,
+                                  child: const Icon(Icons.close,
+                                      size: 18, color: Colors.grey),
+                                ),
+                              ],
+                            ),
+                          );
+                        } else {
+                          return const SizedBox();
+                        }
+                      }),
                       // 실제 댓글 입력창
                       Container(
                         padding: const EdgeInsets.symmetric(
@@ -310,7 +342,9 @@ class _DetailPageState extends State<DetailPage> {
                                 onTap: controller.messageText.value.isNotEmpty
                                     ? (controller.isEditingComment.value
                                         ? controller.editComment
-                                        : controller.sendMessage)
+                                        : controller.isEditingReply.value
+                                            ? controller.editReply
+                                            : controller.sendMessage)
                                     : null,
                                 child: Image.asset(
                                   controller.messageText.value.isNotEmpty

--- a/economic_fe/lib/view/widgets/community/comment_widget.dart
+++ b/economic_fe/lib/view/widgets/community/comment_widget.dart
@@ -91,7 +91,8 @@ class _CommentWidgetState extends State<CommentWidget> {
                           // 더보기 버튼 (수정/삭제/신고)
                           GestureDetector(
                             onTap: () {
-                              _handleOptions(context, widget.isAuthor);
+                              _handleOptions(
+                                  context, widget.isAuthor, widget.isReply);
                             },
                             child: const Icon(Icons.more_horiz,
                                 size: 20, color: Colors.grey),
@@ -100,17 +101,22 @@ class _CommentWidgetState extends State<CommentWidget> {
                       ),
                       const SizedBox(height: 10),
 
-                      // 댓글 내용
+                      // 댓글 내용 표시
                       Text(
-                        widget.comment.content,
-                        style: const TextStyle(
-                          color: Color(0xFF404040),
+                        widget.comment.isDeleted
+                            ? "삭제된 댓글입니다."
+                            : widget.comment.content,
+                        style: TextStyle(
+                          color: widget.comment.isDeleted
+                              ? Colors.grey
+                              : const Color(0xFF404040),
                           fontSize: 14,
                           fontWeight: FontWeight.w400,
                           height: 1.50,
                           letterSpacing: -0.35,
                         ),
                       ),
+
                       const SizedBox(height: 8.5),
 
                       Row(
@@ -175,18 +181,14 @@ class _CommentWidgetState extends State<CommentWidget> {
           ),
         ),
 
-        // 답글 리스트 추가 (들여쓰기 적용)
+        // 대댓글 리스트 (삭제된 댓글이라도 답글이 있으면 그대로 유지)
         if (widget.comment.replies.isNotEmpty)
           Column(
             children: widget.comment.replies.map((reply) {
-              return Column(
-                children: [
-                  CommentWidget(
-                    comment: reply,
-                    isReply: true,
-                    isAuthor: reply.isAuthor,
-                  ),
-                ],
+              return CommentWidget(
+                comment: reply,
+                isReply: true,
+                isAuthor: reply.isAuthor,
               );
             }).toList(),
           ),
@@ -194,13 +196,19 @@ class _CommentWidgetState extends State<CommentWidget> {
     );
   }
 
-  void _handleOptions(BuildContext context, bool isAuthor) {
+  void _handleOptions(BuildContext context, bool isAuthor, bool isReply) {
     OptionsDialog.showOptionsDialog(
       context: context,
       isAuthor: isAuthor,
-      isComment: true,
+      isComment: !isReply, // 댓글이면 true, 대댓글이면 false
       onEdit: () {
-        controller.activateEditMode(widget.comment.id, widget.comment.content);
+        if (isReply) {
+          controller.activateReplyEditMode(
+              widget.comment.id, widget.comment.content);
+        } else {
+          controller.activateEditMode(
+              widget.comment.id, widget.comment.content);
+        }
       },
       onDelete: () {
         Navigator.of(context).pop();

--- a/economic_fe/lib/view_model/community/talk_detail_controller.dart
+++ b/economic_fe/lib/view_model/community/talk_detail_controller.dart
@@ -48,10 +48,12 @@ class TalkDetailController extends GetxController {
           isAuthor: false,
           id: -1,
           isLiked: false,
+          isDeleted: false,
         ),
       ],
       isAuthor: false,
       isLiked: false,
+      isDeleted: false,
     ),
   ]);
 
@@ -68,6 +70,7 @@ class TalkDetailController extends GetxController {
           isAuthor: true,
           id: -1,
           isLiked: false,
+          isDeleted: false,
         ),
       );
     }


### PR DESCRIPTION
## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 답글도 수정 및 삭제가 가능하도록 함
    - 답글 단독 삭제는 아직 구현 X
    - 답글이 존재하는 댓글 삭제 시 → ‘삭제된 댓글입니다.’로 댓글 내용 띄우기
  
## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<img src="https://github.com/user-attachments/assets/d91098cf-adc7-46b0-af7b-6d3404f25d18" width="150">

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- RemoteDataSource 수정
    - 테스트를 위해 임시 accessToken을 사용하는 방식을 유지하기 위해서 제가 구현한 GET 메서드 요청 로직 부분은 일단 _getApiWithHeader로 변경해두었습니다..!
 