### PR TITLE
FEAT: 검색 화면 구현 및 api 연동

### DIFF
--- a/economic_fe/lib/data/models/article_model.dart
+++ b/economic_fe/lib/data/models/article_model.dart
@@ -28,6 +28,23 @@ class ArticleModel with ChangeNotifier {
     this.isScraped,
   });
 
+  /// 영어 카테고리를 한국어로 변환하는 getter
+  String get translatedCategory {
+    const categoryMap = {
+      "ECONOMIC_ANALYSIS": "경기 분석",
+      "NORMAL": "경제 일반",
+      "FINANCE": "금융",
+      "GLOBAL": "국제경제",
+      "REAL_ESTATE": "부동산",
+      "INDUSTRY": "산업경제",
+      "ECONOMIC_POLICY": "정부와 경제 정책",
+      "INVESTMENT": "투자",
+      "OTHER": "기타",
+    };
+
+    return categoryMap[category] ?? "기타"; // 없는 값일 경우 "기타" 반환
+  }
+
   factory ArticleModel.fromJson(Map<String, dynamic> json) {
     return ArticleModel(
       id: json['id'],

--- a/economic_fe/lib/data/models/community/post_model.dart
+++ b/economic_fe/lib/data/models/community/post_model.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class PostModel with ChangeNotifier {
+  int? id;
+  String? title;
+  String? content;
+  String? type;
+  int? likeCount;
+  int? commentCount;
+  String? imageUrl;
+  bool? isScraped;
+  String? createdDate;
+
+  PostModel({
+    this.id,
+    this.title,
+    this.content,
+    this.type,
+    this.likeCount,
+    this.commentCount,
+    this.imageUrl,
+    this.isScraped,
+    this.createdDate,
+  });
+
+  factory PostModel.fromJson(Map<String, dynamic> json) {
+    return PostModel(
+      id: json['id'],
+      title: json['title'],
+      content: json['content'],
+      type: json['type'],
+      likeCount: json['likeCount'],
+      commentCount: json['commentCount'],
+      imageUrl: json['imageUrl'],
+      isScraped: json['isScraped'],
+      createdDate: json['createdDate'],
+    );
+  }
+}

--- a/economic_fe/lib/data/models/dictionary_model.dart
+++ b/economic_fe/lib/data/models/dictionary_model.dart
@@ -1,4 +1,4 @@
-// 뉴스 모델
+// 용어 모델
 
 import 'dart:convert';
 

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -1422,4 +1422,97 @@ class RemoteDataSource {
       return false;
     }
   }
+
+  /// 용어 검색
+  /// api: api/v1/search/terms
+  Future<List<dynamic>> searchTerms(String keyword) async {
+    List<dynamic> searchResults = [];
+    int currentPage = 0;
+    int totalPages = 0; // 초기값 설정
+
+    try {
+      while (currentPage <= totalPages) {
+        String endPoint =
+            'api/v1/search/terms?keyword=$keyword&page=$currentPage';
+
+        var response = await _getApiWithHeader(endPoint, accessToken);
+
+        if (response != null && response["isSuccess"] == true) {
+          var results = response["results"];
+          searchResults.addAll(results["termList"]); // 현재 페이지 데이터 추가
+          totalPages = results["totalPage"]; // 전체 페이지 수 업데이트
+          currentPage++; // 다음 페이지로 이동
+        } else {
+          debugPrint("용어 검색 실패: ${response["message"]}");
+          break;
+        }
+      }
+    } catch (e) {
+      debugPrint("용어 검색 중 오류 발생: $e");
+    }
+
+    return searchResults;
+  }
+
+  /// 게시글 검색
+  /// api: api/v1/search/posts
+  Future<List<dynamic>> searchPosts(String keyword) async {
+    List<dynamic> searchResults = [];
+    int currentPage = 0;
+    int totalPages = 0; // 초기값 설정
+
+    try {
+      while (currentPage <= totalPages) {
+        String endPoint =
+            'api/v1/search/posts?keyword=$keyword&page=$currentPage';
+
+        var response = await _getApiWithHeader(endPoint, accessToken);
+
+        if (response != null && response["isSuccess"] == true) {
+          var results = response["results"];
+          searchResults.addAll(results["postList"]); // 현재 페이지 데이터 추가
+          totalPages = results["totalPage"]; // 전체 페이지 수 업데이트
+          currentPage++; // 다음 페이지로 이동
+        } else {
+          debugPrint("게시글 검색 실패: ${response["message"]}");
+          break;
+        }
+      }
+    } catch (e) {
+      debugPrint("게시글 검색 중 오류 발생: $e");
+    }
+
+    return searchResults;
+  }
+
+  /// 뉴스 검색
+  /// api: api/v1/search/news
+  Future<List<dynamic>> searchNews(String keyword) async {
+    List<dynamic> searchResults = [];
+    int currentPage = 0;
+    int totalPages = 0; // 초기값 설정
+
+    try {
+      while (currentPage <= totalPages) {
+        String endPoint =
+            'api/v1/search/news?keyword=$keyword&page=$currentPage';
+
+        var response = await _getApiWithHeader(endPoint, accessToken);
+
+        if (response != null && response["isSuccess"] == true) {
+          var results = response["results"];
+          searchResults.addAll(results["newsList"]); // 현재 페이지 데이터 추가
+          totalPages = results["totalPage"]; // 전체 페이지 수 업데이트
+          currentPage++; // 다음 페이지로 이동
+        } else {
+          debugPrint("기사 검색 실패: ${response["message"]}");
+          break;
+        }
+      }
+    } catch (e) {
+      debugPrint("기사 검색 중 오류 발생: $e");
+    }
+
+    return searchResults;
+  }
 }

--- a/economic_fe/lib/data/services/remote_data_source.dart
+++ b/economic_fe/lib/data/services/remote_data_source.dart
@@ -1359,4 +1359,67 @@ class RemoteDataSource {
       return false;
     }
   }
+
+  /// 최근 검색어 조회
+  /// API: api/v1/notification
+  Future<dynamic> getRecentSearch() async {
+    String endpoint = 'api/v1/search/recent';
+
+    try {
+      final response = await _getApiWithHeader(endpoint, accessToken);
+
+      if (response != null && response is Map<String, dynamic>) {
+        debugPrint('최근 검색어 데이터 로드 성공');
+        return response;
+      } else {
+        debugPrint('최근 검색어 데이터 로드 실패');
+        return null;
+      }
+    } catch (e) {
+      debugPrint('getRecentSearch Error: $e');
+      return null;
+    }
+  }
+
+  /// 검색어 삭제
+  /// API: api/v1/search/recent
+  Future<bool> deleteRecentSearch(String keyword) async {
+    String endpoint = 'api/v1/search/recent?keyword=$keyword';
+
+    try {
+      final response = await _deleteApi(endpoint);
+
+      if (response == 200) {
+        debugPrint('검색어 삭제 성공');
+        return true;
+      } else {
+        debugPrint('검색어 삭제 실패: (${response.statusCode} ${response.body})');
+        return false;
+      }
+    } catch (e) {
+      debugPrint('검색어 삭제 중 예외 발생: $e');
+      return false;
+    }
+  }
+
+  /// 검색어 전체 삭제
+  /// API: api/v1/search/recent/all
+  Future<bool> deleteRecentSearchAll() async {
+    String endpoint = 'api/v1/search/recent/all';
+
+    try {
+      final response = await _deleteApi(endpoint);
+
+      if (response == 200) {
+        debugPrint('검색어 전체 삭제 성공');
+        return true;
+      } else {
+        debugPrint('검색어 전체 삭제 실패: (${response.statusCode} ${response.body})');
+        return false;
+      }
+    } catch (e) {
+      debugPrint('검색어 전체 삭제 중 예외 발생: $e');
+      return false;
+    }
+  }
 }

--- a/economic_fe/lib/data/services/user_router.dart
+++ b/economic_fe/lib/data/services/user_router.dart
@@ -36,6 +36,7 @@ import 'package:economic_fe/view/screens/profile_setting/part_select_page.dart';
 import 'package:economic_fe/view/screens/profile_setting/profile_setting_page.dart';
 import 'package:economic_fe/view/screens/quiz/level_select_page.dart';
 import 'package:economic_fe/view/screens/quiz/quiz_page.dart';
+import 'package:economic_fe/view/screens/search/search_page.dart';
 import 'package:economic_fe/view/screens/test_answer_page.dart';
 import 'package:economic_fe/view/screens/test_multiple_choice_page.dart';
 import 'package:economic_fe/view/screens/test_ox_page.dart';
@@ -229,6 +230,11 @@ class UserRouter {
       GetPage(
         name: '/notification',
         page: () => const NotificationPage(),
+      ),
+      // 검색 화면
+      GetPage(
+        name: '/search',
+        page: () => const SearchPage(),
       ),
     ];
   }

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/login_exist',
+      initialRoute: '/search',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/search',
+      initialRoute: '/login_exist',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/view/screens/community/detail_page.dart
+++ b/economic_fe/lib/view/screens/community/detail_page.dart
@@ -23,7 +23,7 @@ class _DetailPageState extends State<DetailPage> {
         forceMaterialTransparency: true,
         backgroundColor: Palette.background,
         leading: GestureDetector(
-          onTap: () => controller.goToCommunity(),
+          onTap: () => Get.back(),
           child:
               const Icon(Icons.arrow_back_ios, size: 24, color: Colors.black),
         ),

--- a/economic_fe/lib/view/screens/search/search_page.dart
+++ b/economic_fe/lib/view/screens/search/search_page.dart
@@ -1,0 +1,180 @@
+import 'package:economic_fe/view/theme/palette.dart';
+import 'package:economic_fe/view/widgets/custom_app_bar.dart';
+import 'package:economic_fe/view_model/search/search_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class SearchPage extends StatefulWidget {
+  const SearchPage({super.key});
+
+  @override
+  State<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends State<SearchPage> {
+  final SearchPageController controller = Get.put(SearchPageController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Palette.background,
+      appBar: CustomAppBar(
+        title: '검색',
+        icon: Icons.close,
+        onPress: () {
+          Get.back();
+        },
+      ),
+      body: Column(
+        children: [
+          Center(
+            child: Container(
+              width: MediaQuery.of(context).size.width - 32,
+              height: 42,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              decoration: ShapeDecoration(
+                color: const Color(0xFFF2F3F5),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(52),
+                ),
+              ),
+              child: const Row(
+                children: [
+                  Icon(
+                    Icons.search,
+                    color: Color(0xffa2a2a2),
+                  ),
+                  SizedBox(
+                    width: 8,
+                  ),
+                  Expanded(
+                    child: TextField(
+                      cursorColor: Color(0xff111111),
+                      style: TextStyle(
+                        color: Color(0xFF111111),
+                        fontSize: 16,
+                        fontWeight: FontWeight.w400,
+                        height: 1.40,
+                        letterSpacing: -0.40,
+                      ),
+                      decoration: InputDecoration(
+                        border: InputBorder.none,
+                        hintText: '검색어를 입력해주세요.',
+                        hintStyle: TextStyle(
+                          color: Color(0xFFA2A2A2),
+                          fontSize: 16,
+                          fontWeight: FontWeight.w400,
+                          height: 1.40,
+                          letterSpacing: -0.40,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(
+            height: 21,
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 26),
+              child: Obx(() {
+                if (controller.isLoading.value) {
+                  return const Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+
+                if (controller.keywords.isEmpty) {
+                  return const Padding(
+                    padding: EdgeInsets.only(top: 82),
+                    child: Text(
+                      '최근 검색한 내용이 없습니다.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Color(0xFF767676),
+                        fontSize: 18,
+                        fontWeight: FontWeight.w400,
+                        height: 1.50,
+                      ),
+                    ),
+                  );
+                }
+
+                return Column(
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        const Text(
+                          '최근 검색',
+                          style: TextStyle(
+                            color: Color(0xFF111111),
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            height: 1.50,
+                            letterSpacing: -0.40,
+                          ),
+                        ),
+                        GestureDetector(
+                          onTap: () {
+                            controller.deleteSearchKeywordAll();
+                          },
+                          child: const Text(
+                            '전체삭제',
+                            style: TextStyle(
+                              color: Colors.black,
+                              fontSize: 12,
+                              fontFamily: 'Pretendard Variable',
+                              fontWeight: FontWeight.w400,
+                              height: 1.50,
+                              letterSpacing: -0.30,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    Expanded(
+                      child: ListView.builder(
+                        itemCount: controller.keywords.length,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Text(
+                                  controller.keywords[index],
+                                  style: const TextStyle(
+                                    color: Color(0xFF404040),
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w400,
+                                    height: 1.50,
+                                    letterSpacing: -0.40,
+                                  ),
+                                ),
+                                GestureDetector(
+                                  onTap: () {
+                                    controller.deleteSearchKeyword(
+                                        controller.keywords[index]);
+                                  },
+                                  child: const Icon(Icons.close),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                );
+              }),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/economic_fe/lib/view/screens/search/search_page.dart
+++ b/economic_fe/lib/view/screens/search/search_page.dart
@@ -1,3 +1,6 @@
+import 'package:economic_fe/data/models/article_model.dart';
+import 'package:economic_fe/data/models/community/post_model.dart';
+import 'package:economic_fe/data/models/dictionary_model.dart';
 import 'package:economic_fe/view/theme/palette.dart';
 import 'package:economic_fe/view/widgets/custom_app_bar.dart';
 import 'package:economic_fe/view_model/search/search_controller.dart';
@@ -11,8 +14,27 @@ class SearchPage extends StatefulWidget {
   State<SearchPage> createState() => _SearchPageState();
 }
 
-class _SearchPageState extends State<SearchPage> {
+class _SearchPageState extends State<SearchPage>
+    with SingleTickerProviderStateMixin {
   final SearchPageController controller = Get.put(SearchPageController());
+
+  late TabController tabController; // TabController를 상태에서 직접 관리
+
+  @override
+  void initState() {
+    super.initState();
+    tabController =
+        TabController(length: controller.categories.length, vsync: this);
+    tabController.addListener(() {
+      controller.changeTab(tabController.index);
+    });
+  }
+
+  @override
+  void dispose() {
+    tabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,159 +43,691 @@ class _SearchPageState extends State<SearchPage> {
       appBar: CustomAppBar(
         title: '검색',
         icon: Icons.close,
-        onPress: () {
-          Get.back();
-        },
+        onPress: () => Get.back(),
       ),
       body: Column(
         children: [
-          Center(
-            child: Container(
-              width: MediaQuery.of(context).size.width - 32,
-              height: 42,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-              decoration: ShapeDecoration(
-                color: const Color(0xFFF2F3F5),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(52),
+          _buildSearchBar(),
+          const SizedBox(height: 21),
+          Obx(() =>
+              controller.isSearching.value && controller.isTextNotEmpty.value
+                  ? _buildTabBar()
+                  : _buildRecentSearches()),
+          Expanded(
+            child: Obx(() =>
+                controller.isSearching.value && controller.isTextNotEmpty.value
+                    ? _buildSearchResults()
+                    : const SizedBox()),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 검색창 UI
+  Widget _buildSearchBar() {
+    return Center(
+      child: Container(
+        width: Get.width - 32,
+        height: 42,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        decoration: ShapeDecoration(
+          color: const Color(0xFFF2F3F5),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(52)),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.search, color: Color(0xffa2a2a2)),
+            const SizedBox(width: 8),
+            Expanded(
+              child: TextField(
+                controller: controller.searchController,
+                cursorColor: const Color(0xff111111),
+                style: const TextStyle(fontSize: 16, color: Color(0xFF111111)),
+                decoration: const InputDecoration(
+                  border: InputBorder.none,
+                  hintText: '검색어를 입력해주세요.',
+                  hintStyle: TextStyle(color: Color(0xFFA2A2A2), fontSize: 16),
+                ),
+                onSubmitted: (value) {
+                  controller.search(value);
+                  tabController.index = 0; // 검색 실행 시 기본 카테고리를 "통합"으로 설정
+                },
+              ),
+            ),
+            Obx(() {
+              return controller.isTextNotEmpty.value
+                  ? GestureDetector(
+                      onTap: () {
+                        controller.searchController.clear();
+                        controller.isTextNotEmpty.value = false;
+                      },
+                      child: const Icon(Icons.close, color: Colors.grey),
+                    )
+                  : const SizedBox();
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 가로 스크롤 가능한 탭바 (수정)
+  Widget _buildTabBar() {
+    return SizedBox(
+      height: 50,
+      child: TabBar(
+        tabAlignment: TabAlignment.start,
+        controller: tabController,
+        isScrollable: true,
+        indicatorSize: TabBarIndicatorSize.tab,
+        indicatorWeight: 3,
+        indicatorColor: Colors.black,
+        labelColor: Colors.black,
+        labelStyle: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          height: 1.50,
+          letterSpacing: -0.40,
+        ),
+        unselectedLabelColor: Colors.grey,
+        tabs: controller.categories
+            .map((category) => Tab(text: category))
+            .toList(),
+      ),
+    );
+  }
+
+  /// 검색 결과 UI (탭별 표시)
+  Widget _buildSearchResults() {
+    return Expanded(
+      child: Obx(() {
+        if (controller.selectedTabIndex.value == 0) {
+          return _buildAll(
+            controller.searchTerms,
+            controller.searchNews,
+            controller.searchPosts,
+          );
+        }
+
+        List<dynamic> results;
+        switch (controller.selectedTabIndex.value) {
+          case 1: // 용어사전
+            results = controller.searchTerms;
+            break;
+          case 2: // 경제 기사
+            results = controller.searchNews;
+            break;
+          default: // 일반 게시판
+            results = controller.searchPosts;
+        }
+
+        return results.isEmpty
+            ? const Center(child: Text("결과가 없습니다."))
+            : ListView.separated(
+                separatorBuilder: (_, __) => const Divider(
+                  color: Color(0xffd9d9d9),
+                  thickness: 1,
+                  height: 0,
+                ),
+                itemCount: results.length,
+                itemBuilder: (_, i) {
+                  switch (controller.selectedTabIndex.value) {
+                    case 0: // 통합
+                      return _buildAll(results[i], results[i], results[i]);
+
+                    case 1: // 용어사전 (Dictionary)
+                      return _buildDictionaryCard(results[i]);
+
+                    case 2: // 경제 기사 (News)
+                      return _buildNewsCard(results[i]);
+
+                    case 3: // 일반 게시글
+                      return _buildPostCard(results[i]);
+
+                    default: // 일반 게시글 (Posts)
+                      return _buildPostCard(results[i]);
+                  }
+                },
+              );
+      }),
+    );
+  }
+
+  /// 통합 검색 결과 (카테고리별 표시)
+  Widget _buildAll(List<DictionaryModel> terms, List<ArticleModel> news,
+      List<PostModel> posts) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (terms.isNotEmpty)
+            _buildCategorySection("용어 사전", terms, _buildDictionaryCard, 1),
+          if (news.isNotEmpty)
+            _buildCategorySection("경제 기사", news, _buildNewsCard, 2),
+          if (posts.isNotEmpty)
+            _buildCategorySection("일반 게시판", posts, _buildPostCard, 3),
+        ],
+      ),
+    );
+  }
+
+  /// 통합 탭의 각 카테고리 섹션
+  Widget _buildCategorySection<T>(String title, List<T> items,
+      Widget Function(T) itemBuilder, int tabIndex) {
+    if (items.isEmpty) return const SizedBox(); // 아이템이 없으면 표시하지 않음
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 24, left: 16, right: 16),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  color: Color(0xFF111111),
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  height: 1.50,
+                  letterSpacing: -0.45,
                 ),
               ),
-              child: const Row(
-                children: [
-                  Icon(
-                    Icons.search,
-                    color: Color(0xffa2a2a2),
-                  ),
-                  SizedBox(
-                    width: 8,
-                  ),
-                  Expanded(
-                    child: TextField(
-                      cursorColor: Color(0xff111111),
+              GestureDetector(
+                onTap: () {
+                  controller.changeTab(tabIndex); // 해당 카테고리 탭으로 이동
+                  tabController.animateTo(tabIndex);
+                },
+                child: const Row(
+                  children: [
+                    Text(
+                      '더보기',
                       style: TextStyle(
-                        color: Color(0xFF111111),
-                        fontSize: 16,
+                        color: Color(0xFF767676),
+                        fontSize: 14,
                         fontWeight: FontWeight.w400,
-                        height: 1.40,
-                        letterSpacing: -0.40,
-                      ),
-                      decoration: InputDecoration(
-                        border: InputBorder.none,
-                        hintText: '검색어를 입력해주세요.',
-                        hintStyle: TextStyle(
-                          color: Color(0xFFA2A2A2),
-                          fontSize: 16,
-                          fontWeight: FontWeight.w400,
-                          height: 1.40,
-                          letterSpacing: -0.40,
-                        ),
+                        height: 1.20,
+                        letterSpacing: -0.21,
                       ),
                     ),
+                    Padding(
+                      padding: EdgeInsets.only(top: 3, left: 3),
+                      child: Icon(
+                        Icons.arrow_forward_ios,
+                        size: 12,
+                        color: Color(0xff767676),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        Column(
+          children: List.generate(
+            items.length > 4 ? 4 : items.length, // 최대 4개까지만 표시
+            (i) => Column(
+              children: [
+                itemBuilder(items[i]),
+                if (items.length > 4
+                    ? i != 3
+                    : i < items.length - 1) // 마지막 항목이 아닐 경우 구분선 추가
+                  const Divider(
+                    color: Color(0xffd9d9d9),
+                    thickness: 1,
+                    height: 0,
+                  ),
+              ],
+            ),
+          ),
+        ),
+        const Divider(
+          thickness: 5, // 섹션 구분선
+          color: Color(0xffF2F3F5),
+        ),
+      ],
+    );
+  }
+
+  /// 용어 검색 결과 UI
+  Widget _buildDictionaryCard(DictionaryModel term) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GestureDetector(
+            onTap: () {
+              showTermDetailDialog(context, term);
+            },
+            child: SizedBox(
+              width: 292,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    term.termName!,
+                    style: const TextStyle(
+                      color: Color(0xFF111111),
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                      height: 1.40,
+                      letterSpacing: -0.40,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 8,
+                  ),
+                  Text(
+                    term.termDescription!,
+                    style: const TextStyle(
+                      color: Color(0xFF767676),
+                      fontSize: 14,
+                      fontWeight: FontWeight.w400,
+                      height: 1.40,
+                      letterSpacing: -0.35,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    maxLines: 1,
                   ),
                 ],
               ),
             ),
           ),
-          const SizedBox(
-            height: 21,
-          ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 26),
-              child: Obx(() {
-                if (controller.isLoading.value) {
-                  return const Center(
-                    child: CircularProgressIndicator(),
-                  );
-                }
-
-                if (controller.keywords.isEmpty) {
-                  return const Padding(
-                    padding: EdgeInsets.only(top: 82),
-                    child: Text(
-                      '최근 검색한 내용이 없습니다.',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: Color(0xFF767676),
-                        fontSize: 18,
-                        fontWeight: FontWeight.w400,
-                        height: 1.50,
-                      ),
-                    ),
-                  );
-                }
-
-                return Column(
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        const Text(
-                          '최근 검색',
-                          style: TextStyle(
-                            color: Color(0xFF111111),
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                            height: 1.50,
-                            letterSpacing: -0.40,
-                          ),
-                        ),
-                        GestureDetector(
-                          onTap: () {
-                            controller.deleteSearchKeywordAll();
-                          },
-                          child: const Text(
-                            '전체삭제',
-                            style: TextStyle(
-                              color: Colors.black,
-                              fontSize: 12,
-                              fontFamily: 'Pretendard Variable',
-                              fontWeight: FontWeight.w400,
-                              height: 1.50,
-                              letterSpacing: -0.30,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    Expanded(
-                      child: ListView.builder(
-                        itemCount: controller.keywords.length,
-                        itemBuilder: (context, index) {
-                          return Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 16),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(
-                                  controller.keywords[index],
-                                  style: const TextStyle(
-                                    color: Color(0xFF404040),
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w400,
-                                    height: 1.50,
-                                    letterSpacing: -0.40,
-                                  ),
-                                ),
-                                GestureDetector(
-                                  onTap: () {
-                                    controller.deleteSearchKeyword(
-                                        controller.keywords[index]);
-                                  },
-                                  child: const Icon(Icons.close),
-                                ),
-                              ],
-                            ),
-                          );
-                        },
-                      ),
-                    ),
-                  ],
-                );
-              }),
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: GestureDetector(
+              onTap: () {
+                controller.scrapTermToggle(term);
+              },
+              child: Icon(
+                term.isScraped! ? Icons.bookmark : Icons.bookmark_outline,
+                color: term.isScraped!
+                    ? Palette.buttonColorGreen
+                    : const Color(0xffa2a2a2),
+              ),
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  /// 용어 상세보기 다이얼로그
+  void showTermDetailDialog(BuildContext context, DictionaryModel term) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return Dialog(
+          backgroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Stack(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 14),
+                    // 용어 제목
+                    Text(
+                      term.termName ?? "용어 제목",
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: -0.45,
+                        height: 1.2,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    // 용어 설명
+                    Text(
+                      term.termDescription ?? "상세 내용이 없습니다.",
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: Colors.black87,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                ),
+              ),
+              // 오른쪽 상단 X 버튼 (팝업 닫기)
+              Positioned(
+                top: 16,
+                right: 16,
+                child: GestureDetector(
+                  onTap: () {
+                    Navigator.of(context).pop(); // 팝업 닫기
+                  },
+                  child: const Icon(
+                    Icons.close,
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// 경제 기사 UI
+  Widget _buildNewsCard(ArticleModel news) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            news.translatedCategory,
+            style: const TextStyle(
+              color: Color(0xFF2AD6D6),
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              height: 1.30,
+              letterSpacing: -0.30,
+            ),
+          ),
+          const SizedBox(
+            height: 6,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: 298,
+                child: Text(
+                  maxLines: 2,
+                  news.title!,
+                  style: const TextStyle(
+                    color: Color(0xFF111111),
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    height: 1.30,
+                    letterSpacing: -0.40,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  controller.scrapNewsToggle(news);
+                },
+                child: Icon(
+                  news.isScraped! ? Icons.bookmark : Icons.bookmark_outline,
+                  color: news.isScraped!
+                      ? Palette.buttonColorGreen
+                      : const Color(0xff767676),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(
+            height: 6,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                news.publisher!,
+                style: const TextStyle(
+                  color: Color(0xFF767676),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w400,
+                  height: 1.50,
+                  letterSpacing: -0.30,
+                ),
+              ),
+              Text(
+                news.createdDate!,
+                style: const TextStyle(
+                  color: Color(0xFF767676),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w400,
+                  height: 1.50,
+                  letterSpacing: -0.30,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 일반 게시판 UI
+  Widget _buildPostCard(PostModel post) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: GestureDetector(
+        onTap: () {
+          Get.toNamed(
+            '/community/detail',
+            arguments: post.id,
+          );
+        },
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            SizedBox(
+              width: 235,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    post.title!,
+                    style: const TextStyle(
+                      color: Color(0xFF111111),
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                      height: 1.30,
+                      letterSpacing: -0.40,
+                    ),
+                  ),
+                  Text(
+                    post.content!,
+                    maxLines: 2,
+                    style: const TextStyle(
+                      color: Color(0xFF111111),
+                      fontSize: 14,
+                      fontWeight: FontWeight.w400,
+                      height: 1.50,
+                      letterSpacing: -0.35,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 8,
+                  ),
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.favorite_outline,
+                        size: 20,
+                        color: Color(0xff767676),
+                      ),
+                      const SizedBox(
+                        width: 3,
+                      ),
+                      Text(
+                        '${post.likeCount!}',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Color(0xFF767676),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                          letterSpacing: -0.30,
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 8,
+                      ),
+                      const Icon(
+                        Icons.chat_bubble_outline,
+                        size: 20,
+                        color: Color(0xff767676),
+                      ),
+                      const SizedBox(
+                        width: 3,
+                      ),
+                      Text(
+                        '${post.commentCount!}',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Color(0xFF767676),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                          letterSpacing: -0.30,
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 14,
+                      ),
+                      Text(
+                        post.createdDate!,
+                        style: const TextStyle(
+                          color: Color(0xFF767676),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                          letterSpacing: -0.30,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            post.imageUrl != null
+                ? Container(
+                    width: 66,
+                    height: 66,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFD9D9D9),
+                      borderRadius: BorderRadius.circular(7),
+                      image: DecorationImage(
+                        image: NetworkImage(post.imageUrl!),
+                      ),
+                    ),
+                  )
+                : const SizedBox()
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 최근 검색어 UI
+  Widget _buildRecentSearches() {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 26),
+        child: Obx(() {
+          if (controller.isLoading.value) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (controller.keywords.isEmpty) {
+            return const Padding(
+              padding: EdgeInsets.only(top: 82),
+              child: Text(
+                '최근 검색한 내용이 없습니다.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Color(0xFF767676),
+                  fontSize: 18,
+                  fontWeight: FontWeight.w400,
+                  height: 1.50,
+                ),
+              ),
+            );
+          }
+
+          return Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    '최근 검색',
+                    style: TextStyle(
+                      color: Color(0xFF111111),
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      height: 1.50,
+                      letterSpacing: -0.40,
+                    ),
+                  ),
+                  GestureDetector(
+                    onTap: controller.deleteSearchKeywordAll,
+                    child: const Text(
+                      '전체삭제',
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w400,
+                        height: 1.50,
+                        letterSpacing: -0.30,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Expanded(
+                child: ListView.builder(
+                  itemCount: controller.keywords.length,
+                  itemBuilder: (context, index) {
+                    return Padding(
+                      padding: const EdgeInsets.only(top: 16),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          GestureDetector(
+                            onTap: () {
+                              controller.search(controller.keywords[index]);
+                              controller.searchController.text =
+                                  controller.keywords[index];
+                              tabController.index =
+                                  0; // 🔹 검색 실행 시 "통합" 기본 탭 설정
+                            },
+                            child: Text(
+                              controller.keywords[index],
+                              style: const TextStyle(
+                                color: Color(0xFF404040),
+                                fontSize: 16,
+                                fontWeight: FontWeight.w400,
+                                height: 1.50,
+                                letterSpacing: -0.40,
+                              ),
+                            ),
+                          ),
+                          GestureDetector(
+                            onTap: () => controller.deleteSearchKeyword(
+                                controller.keywords[index]),
+                            child: const Icon(Icons.close),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          );
+        }),
       ),
     );
   }

--- a/economic_fe/lib/view_model/search/search_controller.dart
+++ b/economic_fe/lib/view_model/search/search_controller.dart
@@ -1,0 +1,59 @@
+import 'package:economic_fe/data/services/remote_data_source.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class SearchPageController extends GetxController {
+  final RemoteDataSource remoteDataSource = RemoteDataSource();
+
+  var keywords = <String>[].obs;
+  var isLoading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    fetchSearchKeywords();
+  }
+
+  Future<void> fetchSearchKeywords() async {
+    isLoading(true);
+    try {
+      final response = await remoteDataSource.getRecentSearch();
+      if (response != null && response['isSuccess']) {
+        final searchResults = response['results']['searchKeywords'];
+        if (searchResults != null && searchResults is List) {
+          keywords.assignAll(
+            searchResults
+                .map<String>((item) => item['keyword'].toString())
+                .toList(),
+          );
+        }
+      } else {
+        debugPrint('검색어 데이터가 유효하지 않음');
+      }
+    } catch (e) {
+      debugPrint('Error fetching recent search keywords: $e');
+    } finally {
+      isLoading(false);
+    }
+  }
+
+  /// 개별 검색어 삭제
+  Future<void> deleteSearchKeyword(String keyword) async {
+    bool success = await remoteDataSource.deleteRecentSearch(keyword);
+    if (success) {
+      keywords.remove(keyword);
+    } else {
+      debugPrint('검색어 삭제 실패');
+    }
+  }
+
+  /// 전체 검색어 삭제
+  Future<void> deleteSearchKeywordAll() async {
+    bool success = await remoteDataSource.deleteRecentSearchAll();
+    if (success) {
+      keywords.clear();
+    } else {
+      debugPrint('검색어 전체 삭제 실패');
+    }
+  }
+}

--- a/economic_fe/lib/view_model/search/search_controller.dart
+++ b/economic_fe/lib/view_model/search/search_controller.dart
@@ -1,3 +1,6 @@
+import 'package:economic_fe/data/models/article_model.dart';
+import 'package:economic_fe/data/models/community/post_model.dart';
+import 'package:economic_fe/data/models/dictionary_model.dart';
 import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -5,15 +8,135 @@ import 'package:get/get.dart';
 class SearchPageController extends GetxController {
   final RemoteDataSource remoteDataSource = RemoteDataSource();
 
+  final TextEditingController searchController = TextEditingController();
+
   var keywords = <String>[].obs;
   var isLoading = false.obs;
+  var searchQuery = ''.obs;
+  var isTextNotEmpty = false.obs;
+  var isSearching = false.obs;
+  var selectedTabIndex = 0.obs;
+
+  var searchTerms = <DictionaryModel>[].obs;
+  var searchPosts = <PostModel>[].obs;
+  var searchNews = <ArticleModel>[].obs;
+
+  final List<String> categories = ["통합", "용어사전", "경제 기사", "일반 게시판", "경제 톡톡"];
 
   @override
   void onInit() {
     super.onInit();
     fetchSearchKeywords();
+    searchController.addListener(() {
+      isTextNotEmpty.value = searchController.text.isNotEmpty;
+    });
   }
 
+  @override
+  void dispose() {
+    searchController.dispose();
+    super.dispose();
+  }
+
+  /// 검색 실행
+  Future<void> search(String keyword) async {
+    searchQuery.value = keyword;
+    isSearching.value = true;
+
+    isLoading(true);
+    try {
+      await Future.wait([
+        fetchSearchTermsResults(keyword),
+        fetchSearchPostsResults(keyword),
+        fetchSearchNewsResults(keyword),
+      ]);
+    } catch (e) {
+      debugPrint('검색 중 오류 발생: $e');
+    } finally {
+      isLoading(false);
+    }
+  }
+
+  /// 탭 선택 변경 시 처리
+  void changeTab(int index) {
+    selectedTabIndex.value = index;
+  }
+
+  /// 용어 검색
+  Future<void> fetchSearchTermsResults(String keyword) async {
+    isLoading(true);
+    try {
+      final response = await remoteDataSource.searchTerms(keyword);
+      searchTerms.assignAll(
+          response.map((json) => DictionaryModel.fromJson(json)).toList());
+    } catch (e) {
+      debugPrint('Error fetching terms: $e');
+    } finally {
+      isLoading(false);
+    }
+  }
+
+  /// 용어 스크랩 토글
+  Future<void> scrapTermToggle(DictionaryModel term) async {
+    try {
+      if (term.isScraped!) {
+        await remoteDataSource.deleteScrap(term.termId!);
+      } else {
+        await remoteDataSource.postTermsScrap(term.termId!);
+      }
+
+      term.isScraped = !term.isScraped!;
+      searchTerms.refresh();
+    } catch (e) {
+      debugPrint("스크랩 토글 중 오류 발생: $e");
+    }
+  }
+
+  /// 게시판 검색
+  Future<void> fetchSearchPostsResults(String keyword) async {
+    isLoading(true);
+    try {
+      final response = await remoteDataSource.searchPosts(keyword);
+      searchPosts
+          .assignAll(response.map((json) => PostModel.fromJson(json)).toList());
+    } catch (e) {
+      debugPrint('Error fetching posts: $e');
+    } finally {
+      isLoading(false);
+    }
+  }
+
+  /// 경제 뉴스 검색
+  Future<void> fetchSearchNewsResults(String keyword) async {
+    isLoading(true);
+    try {
+      final response = await remoteDataSource.searchNews(keyword);
+      searchNews.assignAll(
+          response.map((json) => ArticleModel.fromJson(json)).toList());
+    } catch (e) {
+      debugPrint('Error fetching articles: $e');
+    } finally {
+      isLoading(false);
+    }
+  }
+
+  /// 기사 스크랩 토글
+  Future<void> scrapNewsToggle(ArticleModel news) async {
+    try {
+      if (news.isScraped!) {
+        await remoteDataSource.deleteNewsScrap(news.id!);
+      } else {
+        await remoteDataSource.postNewsScrap(news.id!);
+      }
+
+      news.isScraped = !news.isScraped!;
+      searchNews.refresh();
+    } catch (e) {
+      debugPrint("스크랩 토글 중 오류 발생: $e");
+    }
+  }
+
+  /// 최근 검색어 불러오기
   Future<void> fetchSearchKeywords() async {
     isLoading(true);
     try {


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #76 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 검색 화면 UI 구현 및 api 연결
    - 경제 기사: 서버에서 반환하는 영문 카테고리 한글로 변경 (ArticleModel 수정)
- 검색 결과 카테고리 별 UI 구현 및 api 연결

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<table>
<tr><td>최근 검색어 없음</td><td>최근 검색어</td></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/6d936289-a868-4b8b-80fe-66246438b332" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/d95edd4c-0b47-4def-9f41-cbe743307649" width="150"></td>
</tr></table>

<table>
<tr><td>통합 탭</td><td>각 카테고리(용어사전)</td></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/dd9df010-03b4-4ec2-9584-f28a0b66f4bb" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/3699b7ab-9ea6-4a9f-9e79-fcbb20780188" width="150"></td>
</tr></table>

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 경제톡톡 부분은 아직 데이터가 없어서 경제톡톡 제외하고 구현했습니다!