### PR TITLE
FEAT: 프로필 이미지 등록/삭제 api 연동

### DIFF
--- a/economic_fe/lib/data/models/user_profile.dart
+++ b/economic_fe/lib/data/models/user_profile.dart
@@ -7,6 +7,7 @@ class UserProfile {
   String job;
   bool isLearningAlarmAllowed;
   bool isCommunityAlarmAllowed;
+  int? imageId;
 
   UserProfile({
     required this.nickname,
@@ -17,6 +18,7 @@ class UserProfile {
     required this.job,
     this.isLearningAlarmAllowed = true, // 기본값
     this.isCommunityAlarmAllowed = true, // 기본값
+    this.imageId,
   });
 
   // JSON 변환
@@ -30,6 +32,7 @@ class UserProfile {
       job: json['job'] ?? '',
       isLearningAlarmAllowed: json['isLearningAlarmAllowed'] ?? true,
       isCommunityAlarmAllowed: json['isCommunityAlarmAllowed'] ?? true,
+      imageId: json['imageId'],
     );
   }
 
@@ -43,6 +46,7 @@ class UserProfile {
       "job": job,
       "isLearningAlarmAllowed": isLearningAlarmAllowed,
       "isCommunityAlarmAllowed": isCommunityAlarmAllowed,
+      "imageId": imageId,
     };
   }
 }

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/login_exist',
+      initialRoute: '/profile_setting',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/main.dart
+++ b/economic_fe/lib/main.dart
@@ -21,7 +21,7 @@ class RippleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'Ripple',
-      initialRoute: '/profile_setting',
+      initialRoute: '/login_exist',
       getPages: UserRouter.getPages(), // 라우트 설정
     );
   }

--- a/economic_fe/lib/view/screens/profile_setting/basic_info_page.dart
+++ b/economic_fe/lib/view/screens/profile_setting/basic_info_page.dart
@@ -84,25 +84,31 @@ class BasicInfoPage extends StatelessWidget {
                             // 어두운 오버레이 및 삭제 버튼 (삭제 모드일 때 표시)
                             Obx(() {
                               return controller.isDeleteMode.value
-                                  ? Container(
-                                      width: ScreenUtils.getWidth(context, 88),
-                                      height:
-                                          ScreenUtils.getHeight(context, 88),
-                                      decoration: BoxDecoration(
-                                        color: Colors.black
-                                            .withOpacity(0.5), // 반투명 어두운 효과
-                                        shape: BoxShape.circle,
-                                      ),
-                                      child: Center(
-                                        child: GestureDetector(
-                                          onTap: () {
-                                            controller.deleteProfileImage();
-                                            controller.isDeleteMode.value =
-                                                false; // 삭제 후 초기화
-                                          },
-                                          child: const Icon(
-                                            Icons.delete_outline,
-                                            color: Colors.red,
+                                  ? GestureDetector(
+                                      onTap: () {
+                                        controller.isDeleteMode.value = false;
+                                      },
+                                      child: Container(
+                                        width:
+                                            ScreenUtils.getWidth(context, 88),
+                                        height:
+                                            ScreenUtils.getHeight(context, 88),
+                                        decoration: BoxDecoration(
+                                          color: Colors.black
+                                              .withOpacity(0.5), // 반투명 어두운 효과
+                                          shape: BoxShape.circle,
+                                        ),
+                                        child: Center(
+                                          child: GestureDetector(
+                                            onTap: () {
+                                              controller.deleteProfileImage();
+                                              controller.isDeleteMode.value =
+                                                  false; // 삭제 후 초기화
+                                            },
+                                            child: const Icon(
+                                              Icons.delete_outline,
+                                              color: Colors.red,
+                                            ),
                                           ),
                                         ),
                                       ),

--- a/economic_fe/lib/view/screens/profile_setting/basic_info_page.dart
+++ b/economic_fe/lib/view/screens/profile_setting/basic_info_page.dart
@@ -8,6 +8,7 @@ import 'package:economic_fe/view/widgets/profile_setting/basic_gender_button.dar
 import 'package:economic_fe/view/widgets/profile_setting/basic_label.dart';
 import 'package:economic_fe/view/widgets/custom_app_bar.dart';
 import 'package:economic_fe/view_model/profile_setting/basic_controller.dart';
+import 'package:economic_fe/view_model/profile_setting/profile_setting_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -19,6 +20,8 @@ class BasicInfoPage extends StatelessWidget {
   Widget build(BuildContext context) {
     // GetX 컨트롤러 가져오기
     final BasicController controller = Get.put(BasicController());
+    final ProfileSettingController profileController =
+        Get.find<ProfileSettingController>();
 
     return Scaffold(
       backgroundColor: Palette.background,
@@ -50,19 +53,66 @@ class BasicInfoPage extends StatelessWidget {
                       ),
                     ),
                     child: Obx(() {
-                      return controller.selectedProfileImage.value != null
-                          ? ClipOval(
-                              child: Image.file(
-                                File(controller.selectedProfileImage.value!),
-                                fit: BoxFit.cover,
-                                width: ScreenUtils.getWidth(context, 88),
-                                height: ScreenUtils.getHeight(context, 88),
-                              ),
-                            )
-                          : Icon(
-                              Icons.person,
-                              size: ScreenUtils.getWidth(context, 43),
-                            );
+                      return GestureDetector(
+                        onTap: () {
+                          if (controller.selectedProfileImage.value != null) {
+                            controller.isDeleteMode.value =
+                                true; // 어두운 오버레이 활성화
+                          }
+                        },
+                        child: Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            // 프로필 이미지 또는 기본 아이콘
+                            ClipOval(
+                              child: controller.selectedProfileImage.value !=
+                                      null
+                                  ? Image.file(
+                                      File(controller
+                                          .selectedProfileImage.value!),
+                                      fit: BoxFit.cover,
+                                      width: ScreenUtils.getWidth(context, 88),
+                                      height:
+                                          ScreenUtils.getHeight(context, 88),
+                                    )
+                                  : Icon(
+                                      Icons.person,
+                                      size: ScreenUtils.getWidth(context, 43),
+                                    ),
+                            ),
+
+                            // 어두운 오버레이 및 삭제 버튼 (삭제 모드일 때 표시)
+                            Obx(() {
+                              return controller.isDeleteMode.value
+                                  ? Container(
+                                      width: ScreenUtils.getWidth(context, 88),
+                                      height:
+                                          ScreenUtils.getHeight(context, 88),
+                                      decoration: BoxDecoration(
+                                        color: Colors.black
+                                            .withOpacity(0.5), // 반투명 어두운 효과
+                                        shape: BoxShape.circle,
+                                      ),
+                                      child: Center(
+                                        child: GestureDetector(
+                                          onTap: () {
+                                            controller.deleteProfileImage();
+                                            controller.isDeleteMode.value =
+                                                false; // 삭제 후 초기화
+                                          },
+                                          child: const Icon(
+                                            Icons.delete_outline,
+                                            color: Colors.red,
+                                          ),
+                                        ),
+                                      ),
+                                    )
+                                  : const SizedBox
+                                      .shrink(); // 삭제 모드가 아닐 때는 아무것도 표시 안 함
+                            }),
+                          ],
+                        ),
+                      );
                     }),
                   ),
                   Positioned(

--- a/economic_fe/lib/view_model/profile_setting/basic_controller.dart
+++ b/economic_fe/lib/view_model/profile_setting/basic_controller.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:economic_fe/data/services/date_picker_service.dart';
 import 'package:economic_fe/data/services/image_picker_service.dart';
+import 'package:economic_fe/data/services/remote_data_source.dart';
 import 'package:economic_fe/view_model/profile_setting/profile_setting_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -13,6 +16,12 @@ class BasicController extends GetxController {
   var nickname = ''.obs;
   var isValid = false.obs;
   var errorMessage = ''.obs;
+
+  // 프로필 이미지
+  var imageId = Rxn<int>();
+
+  // 삭제 모드 활성화 여부
+  var isDeleteMode = false.obs;
 
   // 닉네임 입력 컨트롤러 (키보드 입력 문제 해결)
   final TextEditingController nicknameController = TextEditingController();
@@ -45,6 +54,44 @@ class BasicController extends GetxController {
     final image = await _imagePickerService.showImagePickerDialog(context);
     if (image != null) {
       selectedProfileImage.value = image.path;
+
+      // 이미지 업로드 후 imageId 받아오기
+      int? uploadedImageId =
+          await RemoteDataSource.uploadProfileImage(File(image.path));
+
+      if (uploadedImageId != null) {
+        imageId.value = uploadedImageId; // Rxn<int>로 변경
+        imageId.refresh(); // UI에 반영
+
+        // ProfileSettingController에 imageId 업데이트
+        Get.find<ProfileSettingController>()
+            .updateProfileField('imageId', imageId.value);
+        Get.snackbar('성공', '프로필 이미지가 업데이트되었습니다.');
+      } else {
+        Get.snackbar('실패', '프로필 이미지 등록에 실패하였습니다.');
+      }
+    }
+  }
+
+  /// 프로필 이미지 삭제 메서드
+  Future<void> deleteProfileImage() async {
+    final ProfileSettingController profileController =
+        Get.find<ProfileSettingController>();
+
+    if (imageId.value != null) {
+      bool isDeleted = await RemoteDataSource.deleteImage(imageId.value!);
+
+      if (isDeleted) {
+        // 프로필 이미지 초기화
+        imageId.value = null; // imageId를 null로 설정
+        selectedProfileImage.value = null;
+        imageId.refresh(); // UI 반영
+        profileController.updateProfileField('imageId', null);
+
+        Get.snackbar('성공', '프로필 이미지가 삭제되었습니다.');
+      } else {
+        Get.snackbar('오류', '이미지 삭제에 실패했습니다.');
+      }
     }
   }
 
@@ -65,7 +112,7 @@ class BasicController extends GetxController {
 
     _updateProfileField('nickname', value);
 
-    // ✅ 저장 버튼 상태 업데이트
+    // 저장 버튼 상태 업데이트
     _updateSaveButtonState();
   }
 
@@ -80,7 +127,7 @@ class BasicController extends GetxController {
     // UI 강제 업데이트
     selectedGender.refresh();
 
-    // ✅ 저장 버튼 상태 업데이트
+    // 저장 버튼 상태 업데이트
     _updateSaveButtonState();
   }
 
@@ -92,7 +139,7 @@ class BasicController extends GetxController {
           '${pickedDate.year}-${pickedDate.month.toString().padLeft(2, '0')}-${pickedDate.day.toString().padLeft(2, '0')}';
       _updateProfileField('birthDate', selectedBirthday.value);
 
-      // ✅ 저장 버튼 상태 업데이트
+      // 저장 버튼 상태 업데이트
       _updateSaveButtonState();
     }
   }

--- a/economic_fe/lib/view_model/profile_setting/profile_setting_controller.dart
+++ b/economic_fe/lib/view_model/profile_setting/profile_setting_controller.dart
@@ -21,6 +21,7 @@ class ProfileSettingController extends GetxController {
     profileIntro: '',
     businessType: '',
     job: '',
+    imageId: null,
   ).obs;
 
   // 입력 완료 여부
@@ -66,6 +67,9 @@ class ProfileSettingController extends GetxController {
             profile.job = value;
             isJobCompleted.value = value.isNotEmpty;
             break;
+          case 'imageId':
+            profile.imageId = value;
+            break;
         }
       }
     });
@@ -78,8 +82,7 @@ class ProfileSettingController extends GetxController {
   void updateProfileCompletionStatus() {
     bool infoCompleted = userProfile.value.nickname.isNotEmpty &&
         userProfile.value.birthDate.isNotEmpty &&
-        userProfile.value.gender.isNotEmpty &&
-        userProfile.value.profileIntro.isNotEmpty;
+        userProfile.value.gender.isNotEmpty;
 
     isInfoCompleted.value = infoCompleted;
   }
@@ -112,10 +115,17 @@ class ProfileSettingController extends GetxController {
       return;
     }
 
-    print("🚀 전송 데이터: ${userProfile.value.toJson()}");
+    // userProfile 데이터를 Map으로 변환
+    Map<String, dynamic> profileData = userProfile.value.toJson();
 
-    bool success =
-        await remoteDataSource.registerUserProfile(userProfile.value.toJson());
+    // imageId가 null이면 Map에서 제거
+    if (profileData['imageId'] == null) {
+      profileData.remove('imageId');
+    }
+
+    print("전송 데이터: $profileData");
+
+    bool success = await remoteDataSource.registerUserProfile(profileData);
 
     if (success) {
       Get.snackbar('성공', '프로필 등록이 완료되었습니다.');


### PR DESCRIPTION
## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 프로필 이미지 등록 api 연동
    - 이미지가 선택된 상태에서 해당 이미지를 클릭하면 삭제 버튼 보이도록 구현

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<table>
<tr><td>이미지 등록(id 발급)</td><td>이미지 클릭 시</td><td>이미지 삭제</td></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/4c6edbce-7870-4b4d-ba9b-3506bb8d6896" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/09477ffc-001e-4128-857f-77785c789024" width="150"></td>
<td><img src="https://github.com/user-attachments/assets/2179e82e-5ed9-488f-93fe-69927b2add55" width="150"></td>
</tr></table>
